### PR TITLE
Update to NumPy 1.16

### DIFF
--- a/recipe/0001-fix-windows-case-sensitivity.patch
+++ b/recipe/0001-fix-windows-case-sensitivity.patch
@@ -1,4 +1,4 @@
-From e71cb27f4978125277cc260f799c6266152bb31d Mon Sep 17 00:00:00 2001
+From 1d2304a4442152e7f5f273d6539576c4145d45de Mon Sep 17 00:00:00 2001
 From: Michael Sarahan <msarahan@gmail.com>
 Date: Mon, 11 Jun 2018 16:37:27 -0500
 Subject: [PATCH 01/15] fix windows case sensitivity
@@ -51,5 +51,5 @@ index 990d0ae..3d33b47 100644
          del fp
  
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0002-simplify-arch-flags.patch
+++ b/recipe/0002-simplify-arch-flags.patch
@@ -1,4 +1,4 @@
-From fdcfeae4626d1189c72819e7af180478618bd5e7 Mon Sep 17 00:00:00 2001
+From cc73e3f7de479b6337f1a0447d7a7cba7d72f723 Mon Sep 17 00:00:00 2001
 From: Michael Sarahan <msarahan@gmail.com>
 Date: Mon, 11 Jun 2018 16:36:07 -0500
 Subject: [PATCH 02/15] simplify arch flags
@@ -8,10 +8,10 @@ Subject: [PATCH 02/15] simplify arch flags
  1 file changed, 1 insertion(+), 12 deletions(-)
 
 diff --git a/numpy/distutils/fcompiler/gnu.py b/numpy/distutils/fcompiler/gnu.py
-index 0ebbe79..56e9be5 100644
+index 81769e5..ffab514 100644
 --- a/numpy/distutils/fcompiler/gnu.py
 +++ b/numpy/distutils/fcompiler/gnu.py
-@@ -306,20 +306,9 @@ class Gnu95FCompiler(GnuFCompiler):
+@@ -324,20 +324,9 @@ class Gnu95FCompiler(GnuFCompiler):
      g2c = 'gfortran'
  
      def _universal_flags(self, cmd):
@@ -34,5 +34,5 @@ index 0ebbe79..56e9be5 100644
      def get_flags(self):
          flags = GnuFCompiler.get_flags(self)
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0003-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
+++ b/recipe/0003-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
@@ -1,4 +1,4 @@
-From 767249bf8beec1c9b4cbdfa485be282ef415621e Mon Sep 17 00:00:00 2001
+From 6b0eb476f53a17ab811fbaae1439b04da3939846 Mon Sep 17 00:00:00 2001
 From: Michael Sarahan <msarahan@gmail.com>
 Date: Mon, 11 Jun 2018 16:36:41 -0500
 Subject: [PATCH 03/15] Obtain and prefer custom gfortran from env variable
@@ -8,10 +8,10 @@ Subject: [PATCH 03/15] Obtain and prefer custom gfortran from env variable
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/numpy/distutils/fcompiler/gnu.py b/numpy/distutils/fcompiler/gnu.py
-index 56e9be5..ab5876a 100644
+index ffab514..0b034be 100644
 --- a/numpy/distutils/fcompiler/gnu.py
 +++ b/numpy/distutils/fcompiler/gnu.py
-@@ -285,7 +285,14 @@ class Gnu95FCompiler(GnuFCompiler):
+@@ -297,7 +297,14 @@ class Gnu95FCompiler(GnuFCompiler):
                      self.executables[key].append('-mno-cygwin')
          return v
  
@@ -28,5 +28,5 @@ index 56e9be5..ab5876a 100644
          'version_cmd'  : ["<F90>", "-dumpversion"],
          'compiler_f77' : [None, "-Wall", "-g", "-ffixed-form",
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0004-disable-memmap-filename-test-due-to-CI-link-confusio.patch
+++ b/recipe/0004-disable-memmap-filename-test-due-to-CI-link-confusio.patch
@@ -1,4 +1,4 @@
-From 9e013b972cbecc1faf9f3d44ccd7c94eea81e0ba Mon Sep 17 00:00:00 2001
+From 9aa4f5b38fe609a41e5b7da16d278f1f62d1d3c2 Mon Sep 17 00:00:00 2001
 From: Michael Sarahan <msarahan@gmail.com>
 Date: Mon, 11 Jun 2018 16:39:37 -0500
 Subject: [PATCH 04/15] disable memmap filename test due to CI link confusion
@@ -47,5 +47,5 @@ index 3d33b47..425d90d 100644
          fp = memmap(self.tmpfp, dtype=self.dtype, mode="w+",
                      shape=self.shape)
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0005-disable-broken-tests.patch
+++ b/recipe/0005-disable-broken-tests.patch
@@ -1,19 +1,19 @@
-From 19b5ec65aa462fd455c6f176ad6f5561e97c4fe3 Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Tue, 12 Jun 2018 09:54:13 -0500
+From 6b4283f3c4173271c6dbad87f08d3b63acaed691 Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Thu, 21 Feb 2019 18:10:45 +0000
 Subject: [PATCH 05/15] disable broken tests
 
 MKL messes up this error state, and these tests don't work.
 ---
  numpy/core/tests/test_einsum.py   |  3 ---
- numpy/core/tests/test_errstate.py | 15 ---------------
- 2 files changed, 18 deletions(-)
+ numpy/core/tests/test_errstate.py | 11 -----------
+ 2 files changed, 14 deletions(-)
 
 diff --git a/numpy/core/tests/test_einsum.py b/numpy/core/tests/test_einsum.py
-index 8ce374a..3be1790 100644
+index 3be4a8a..af3f95e 100644
 --- a/numpy/core/tests/test_einsum.py
 +++ b/numpy/core/tests/test_einsum.py
-@@ -526,9 +526,6 @@ class TestEinsum(object):
+@@ -524,9 +524,6 @@ class TestEinsum(object):
      def test_einsum_sums_uint8(self):
          self.check_einsum_sums('u1')
  
@@ -24,10 +24,10 @@ index 8ce374a..3be1790 100644
          self.check_einsum_sums('u2')
  
 diff --git a/numpy/core/tests/test_errstate.py b/numpy/core/tests/test_errstate.py
-index 4f61119..0b7a528 100644
+index 670d485..3d43040 100644
 --- a/numpy/core/tests/test_errstate.py
 +++ b/numpy/core/tests/test_errstate.py
-@@ -8,21 +8,6 @@ from numpy.testing import assert_
+@@ -8,17 +8,6 @@ from numpy.testing import assert_, assert_raises
  
  
  class TestErrstate(object):
@@ -39,16 +39,12 @@ index 4f61119..0b7a528 100644
 -            with np.errstate(invalid='ignore'):
 -                np.sqrt(a)
 -            # While this should fail!
--            try:
+-            with assert_raises(FloatingPointError):
 -                np.sqrt(a)
--            except FloatingPointError:
--                pass
--            else:
--                self.fail("Did not raise an invalid error")
 -
      def test_divide(self):
          with np.errstate(all='raise', under='ignore'):
              a = -np.arange(3)
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0006-use-mklfft-when-available.patch
+++ b/recipe/0006-use-mklfft-when-available.patch
@@ -1,18 +1,32 @@
-From 1cff014ed8cf5955c8832cac8b1eb8d095859702 Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Thu, 26 Jul 2018 11:23:44 -0500
+From 3cb77ea74b41bafca39bb3f7871b76abbc22d796 Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 10:25:01 +0000
 Subject: [PATCH 06/15] use mklfft when available
 
 ---
- numpy/fft/__init__.py | 41 +++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 41 insertions(+)
+ numpy/core/tests/test_overrides.py |  1 +
+ numpy/fft/__init__.py              | 41 ++++++++++++++++++++++++++++++
+ numpy/tests/test_public_api.py     |  2 +-
+ 3 files changed, 43 insertions(+), 1 deletion(-)
 
+diff --git a/numpy/core/tests/test_overrides.py b/numpy/core/tests/test_overrides.py
+index 62b2a3e..ad0968d 100644
+--- a/numpy/core/tests/test_overrides.py
++++ b/numpy/core/tests/test_overrides.py
+@@ -366,6 +366,7 @@ class TestNDArrayMethods(object):
+ 
+ class TestNumPyFunctions(object):
+ 
++    @pytest.mark.xfail(reason="numpy.fft is patched in MKL-optimized NumPy")
+     def test_set_module(self):
+         assert_equal(np.sum.__module__, 'numpy')
+         assert_equal(np.char.equal.__module__, 'numpy.char')
 diff --git a/numpy/fft/__init__.py b/numpy/fft/__init__.py
-index bbb6ec8..7658c2e 100644
+index 44243b4..8298307 100644
 --- a/numpy/fft/__init__.py
 +++ b/numpy/fft/__init__.py
 @@ -9,3 +9,44 @@ from .helper import *
- from numpy.testing._private.pytesttester import PytestTester
+ from numpy._pytesttester import PytestTester
  test = PytestTester(__name__)
  del PytestTester
 +
@@ -56,6 +70,19 @@ index bbb6ec8..7658c2e 100644
 +    del _nfft
 +
 +del patch_fft
+diff --git a/numpy/tests/test_public_api.py b/numpy/tests/test_public_api.py
+index 194f8ec..e1df3df 100644
+--- a/numpy/tests/test_public_api.py
++++ b/numpy/tests/test_public_api.py
+@@ -74,7 +74,7 @@ def test_numpy_linalg():
+     bad_results = check_dir(np.linalg)
+     assert bad_results == {}
+ 
+-
++@pytest.mark.xfail(reason="numpy.fft is patched in MKL-optimized NumPy", run=False)
+ def test_numpy_fft():
+     bad_results = check_dir(np.fft)
+     assert bad_results == {}
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0007-define-mkl_version-in-__init__.py.patch
+++ b/recipe/0007-define-mkl_version-in-__init__.py.patch
@@ -1,6 +1,6 @@
-From ac53a3d1bc90b2e8c6163782cc1ca8daa468ae93 Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Thu, 26 Jul 2018 11:30:25 -0500
+From 7acdbbcf080d4f9c06dcf8912ccf4d1b2184f97a Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 10:44:00 +0000
 Subject: [PATCH 07/15] define mkl_version in __init__.py
 
 ---
@@ -8,10 +8,10 @@ Subject: [PATCH 07/15] define mkl_version in __init__.py
  1 file changed, 2 insertions(+)
 
 diff --git a/numpy/__init__.py b/numpy/__init__.py
-index 1f60f07..144569d 100644
+index ba88c73..3723daa 100644
 --- a/numpy/__init__.py
 +++ b/numpy/__init__.py
-@@ -201,6 +201,8 @@ else:
+@@ -192,6 +192,8 @@ else:
      del PytestTester
  
  
@@ -21,5 +21,5 @@ index 1f60f07..144569d 100644
          """
          Quick sanity checks for common bugs caused by environment.
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0008-intel-umath-optimizations.patch
+++ b/recipe/0008-intel-umath-optimizations.patch
@@ -1,26 +1,26 @@
-From 5d6d66f6346ecd8a7ad12d4ee30fc83fdb8da9d5 Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Thu, 26 Jul 2018 11:30:59 -0500
+From a0103d8b50dd15bad287f25d0fa9b38d6b9f2f5d Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 10:36:44 +0000
 Subject: [PATCH 08/15] intel umath optimizations
 
 ---
- numpy/core/code_generators/generate_umath.py   |   64 +
- numpy/core/code_generators/ufunc_docstrings.py |   63 +-
- numpy/core/include/numpy/npy_math.h            |   12 +
- numpy/core/setup.py                            |   33 +-
- numpy/core/setup_common.py                     |    8 +-
- numpy/core/src/npymath/npy_math_complex.c.src  |   22 +-
- numpy/core/src/npymath/npy_math_internal.h.src |   25 +-
- numpy/core/src/umath/funcs.inc.src             |   14 +
- numpy/core/src/umath/loops.c.src               | 1871 +++++++++++++++++++++---
- numpy/core/src/umath/loops.h.src               |   10 +-
- 10 files changed, 1925 insertions(+), 197 deletions(-)
+ numpy/core/code_generators/generate_umath.py  |   64 +
+ .../core/code_generators/ufunc_docstrings.py  |   63 +-
+ numpy/core/include/numpy/npy_math.h           |   12 +
+ numpy/core/setup.py                           |   26 +-
+ numpy/core/setup_common.py                    |    8 +-
+ numpy/core/src/npymath/npy_math_complex.c.src |   22 +-
+ .../core/src/npymath/npy_math_internal.h.src  |   25 +-
+ numpy/core/src/umath/funcs.inc.src            |   14 +
+ numpy/core/src/umath/loops.c.src              | 1862 +++++++++++++++--
+ numpy/core/src/umath/loops.h.src              |   10 +-
+ 10 files changed, 1915 insertions(+), 191 deletions(-)
 
 diff --git a/numpy/core/code_generators/generate_umath.py b/numpy/core/code_generators/generate_umath.py
-index 632bcb4..94b2a13 100644
+index f5ee02c..bb37080 100644
 --- a/numpy/core/code_generators/generate_umath.py
 +++ b/numpy/core/code_generators/generate_umath.py
-@@ -601,6 +601,8 @@ defdict = {
+@@ -604,6 +604,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.arccos'),
            None,
@@ -29,7 +29,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='acos', astype={'e':'f'}),
            TD(P, f='arccos'),
            ),
-@@ -608,6 +610,8 @@ defdict = {
+@@ -611,6 +613,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.arccosh'),
            None,
@@ -38,7 +38,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='acosh', astype={'e':'f'}),
            TD(P, f='arccosh'),
            ),
-@@ -615,6 +619,8 @@ defdict = {
+@@ -618,6 +622,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.arcsin'),
            None,
@@ -47,7 +47,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='asin', astype={'e':'f'}),
            TD(P, f='arcsin'),
            ),
-@@ -622,6 +628,8 @@ defdict = {
+@@ -625,6 +631,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.arcsinh'),
            None,
@@ -56,7 +56,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='asinh', astype={'e':'f'}),
            TD(P, f='arcsinh'),
            ),
-@@ -629,6 +637,8 @@ defdict = {
+@@ -632,6 +640,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.arctan'),
            None,
@@ -65,7 +65,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='atan', astype={'e':'f'}),
            TD(P, f='arctan'),
            ),
-@@ -636,6 +646,8 @@ defdict = {
+@@ -639,6 +649,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.arctanh'),
            None,
@@ -74,7 +74,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='atanh', astype={'e':'f'}),
            TD(P, f='arctanh'),
            ),
-@@ -643,6 +655,8 @@ defdict = {
+@@ -646,6 +658,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.cos'),
            None,
@@ -83,7 +83,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='cos', astype={'e':'f'}),
            TD(P, f='cos'),
            ),
-@@ -650,6 +664,8 @@ defdict = {
+@@ -653,6 +667,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.sin'),
            None,
@@ -92,7 +92,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='sin', astype={'e':'f'}),
            TD(P, f='sin'),
            ),
-@@ -657,6 +673,8 @@ defdict = {
+@@ -660,6 +676,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.tan'),
            None,
@@ -101,7 +101,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='tan', astype={'e':'f'}),
            TD(P, f='tan'),
            ),
-@@ -664,6 +682,8 @@ defdict = {
+@@ -667,6 +685,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.cosh'),
            None,
@@ -110,7 +110,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='cosh', astype={'e':'f'}),
            TD(P, f='cosh'),
            ),
-@@ -671,6 +691,8 @@ defdict = {
+@@ -674,6 +694,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.sinh'),
            None,
@@ -119,7 +119,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='sinh', astype={'e':'f'}),
            TD(P, f='sinh'),
            ),
-@@ -678,6 +700,8 @@ defdict = {
+@@ -681,6 +703,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.tanh'),
            None,
@@ -128,7 +128,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='tanh', astype={'e':'f'}),
            TD(P, f='tanh'),
            ),
-@@ -685,6 +709,8 @@ defdict = {
+@@ -688,6 +712,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.exp'),
            None,
@@ -137,7 +137,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='exp', astype={'e':'f'}),
            TD(P, f='exp'),
            ),
-@@ -699,13 +725,26 @@ defdict = {
+@@ -702,13 +728,26 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.expm1'),
            None,
@@ -152,7 +152,7 @@ index 632bcb4..94b2a13 100644
 +          None,
 +          TD('e', f='erf', astype={'e':'f'}),
 +          TD(inexactvec),
-+          TD(inexact, f='erf', astype={'e':'f'}),
++          TD(flts, f='erf', astype={'e':'f'}),
 +          TD(P, f='erf'),
 +          ),
  'log':
@@ -164,7 +164,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='log', astype={'e':'f'}),
            TD(P, f='log'),
            ),
-@@ -720,6 +759,8 @@ defdict = {
+@@ -723,6 +762,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.log10'),
            None,
@@ -173,7 +173,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='log10', astype={'e':'f'}),
            TD(P, f='log10'),
            ),
-@@ -727,6 +768,8 @@ defdict = {
+@@ -730,6 +771,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.log1p'),
            None,
@@ -182,7 +182,7 @@ index 632bcb4..94b2a13 100644
            TD(inexact, f='log1p', astype={'e':'f'}),
            TD(P, f='log1p'),
            ),
-@@ -739,10 +782,21 @@ defdict = {
+@@ -742,10 +785,21 @@ defdict = {
            TD(inexact, f='sqrt', astype={'e':'f'}),
            TD(P, f='sqrt'),
            ),
@@ -204,7 +204,7 @@ index 632bcb4..94b2a13 100644
            TD(flts, f='cbrt', astype={'e':'f'}),
            TD(P, f='cbrt'),
            ),
-@@ -750,6 +804,8 @@ defdict = {
+@@ -753,6 +807,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.ceil'),
            None,
@@ -213,7 +213,7 @@ index 632bcb4..94b2a13 100644
            TD(flts, f='ceil', astype={'e':'f'}),
            TD(P, f='ceil'),
            ),
-@@ -757,6 +813,8 @@ defdict = {
+@@ -760,6 +816,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.trunc'),
            None,
@@ -222,7 +222,7 @@ index 632bcb4..94b2a13 100644
            TD(flts, f='trunc', astype={'e':'f'}),
            TD(P, f='trunc'),
            ),
-@@ -764,6 +822,8 @@ defdict = {
+@@ -767,6 +825,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.fabs'),
            None,
@@ -231,7 +231,7 @@ index 632bcb4..94b2a13 100644
            TD(flts, f='fabs', astype={'e':'f'}),
            TD(P, f='fabs'),
         ),
-@@ -771,6 +831,8 @@ defdict = {
+@@ -774,6 +834,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.floor'),
            None,
@@ -240,7 +240,7 @@ index 632bcb4..94b2a13 100644
            TD(flts, f='floor', astype={'e':'f'}),
            TD(P, f='floor'),
            ),
-@@ -778,6 +840,8 @@ defdict = {
+@@ -781,6 +843,8 @@ defdict = {
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.rint'),
            None,
@@ -250,10 +250,10 @@ index 632bcb4..94b2a13 100644
            TD(P, f='rint'),
            ),
 diff --git a/numpy/core/code_generators/ufunc_docstrings.py b/numpy/core/code_generators/ufunc_docstrings.py
-index f7d58a2..39b8827 100644
+index 8a690c4..9cf52c0 100644
 --- a/numpy/core/code_generators/ufunc_docstrings.py
 +++ b/numpy/core/code_generators/ufunc_docstrings.py
-@@ -1099,6 +1099,40 @@ add_newdoc('numpy.core.umath', 'equal',
+@@ -1100,6 +1100,40 @@ add_newdoc('numpy.core.umath', 'equal',
  
      """)
  
@@ -294,7 +294,7 @@ index f7d58a2..39b8827 100644
  add_newdoc('numpy.core.umath', 'exp',
      """
      Calculate the exponential of all elements in the input array.
-@@ -3409,6 +3443,34 @@ add_newdoc('numpy.core.umath', 'sqrt',
+@@ -3533,6 +3567,34 @@ add_newdoc('numpy.core.umath', 'sqrt',
  
      """)
  
@@ -329,7 +329,7 @@ index f7d58a2..39b8827 100644
  add_newdoc('numpy.core.umath', 'cbrt',
      """
      Return the cube-root of an array, element-wise.
-@@ -3429,7 +3491,6 @@ add_newdoc('numpy.core.umath', 'cbrt',
+@@ -3553,7 +3615,6 @@ add_newdoc('numpy.core.umath', 'cbrt',
          If `out` was provided, `y` is a reference to it.
          $OUT_SCALAR_1
  
@@ -419,10 +419,10 @@ index 582390c..91ea82e 100644
  npy_clongdouble npy_ccosl(npy_clongdouble z);
  npy_clongdouble npy_csinl(npy_clongdouble z);
 diff --git a/numpy/core/setup.py b/numpy/core/setup.py
-index f826b27..5feb851 100644
+index 467b590..fb0386e 100644
 --- a/numpy/core/setup.py
 +++ b/numpy/core/setup.py
-@@ -9,6 +9,7 @@ import warnings
+@@ -8,6 +8,7 @@ import warnings
  import platform
  from os.path import join
  from numpy.distutils import log
@@ -430,7 +430,7 @@ index f826b27..5feb851 100644
  from distutils.dep_util import newer
  from distutils.sysconfig import get_config_var
  from numpy._build_utils.apple_accelerate import (
-@@ -760,7 +761,6 @@ def configuration(parent_package='',top_path=None):
+@@ -807,7 +808,6 @@ def configuration(parent_package='',top_path=None):
              join('include', 'numpy', 'noprefix.h'),
              join('include', 'numpy', 'npy_interrupt.h'),
              join('include', 'numpy', 'npy_3kcompat.h'),
@@ -438,7 +438,7 @@ index f826b27..5feb851 100644
              join('include', 'numpy', 'halffloat.h'),
              join('include', 'numpy', 'npy_common.h'),
              join('include', 'numpy', 'npy_os.h'),
-@@ -772,7 +772,7 @@ def configuration(parent_package='',top_path=None):
+@@ -819,7 +819,7 @@ def configuration(parent_package='',top_path=None):
              join('include', 'numpy', 'npy_1_7_deprecated_api.h'),
              # add library sources as distuils does not consider libraries
              # dependencies
@@ -447,19 +447,7 @@ index f826b27..5feb851 100644
  
      multiarray_src = [
              join('src', 'multiarray', 'alloc.c'),
-@@ -849,9 +849,10 @@ def configuration(parent_package='',top_path=None):
-                                   generate_numpy_api,
-                                   join(codegen_dir, 'generate_numpy_api.py'),
-                                   join('*.py')],
-+                         extra_compile_args=['/Qstd=c99' if platform.system() == "Windows" else ''],
-                          depends=deps + multiarray_deps,
-                          libraries=['npymath', 'npysort'],
--                         extra_info=extra_info)
-+                         extra_info=get_info('mkl'))
- 
-     #######################################################################
-     #                           umath module                              #
-@@ -870,13 +871,14 @@ def configuration(parent_package='',top_path=None):
+@@ -886,13 +886,14 @@ def configuration(parent_package='',top_path=None):
              f.close()
          return []
  
@@ -473,48 +461,47 @@ index f826b27..5feb851 100644
              join('src', 'umath', 'simd.inc.src'),
 -            join('src', 'umath', 'loops.h.src'),
 -            join('src', 'umath', 'loops.c.src'),
+             join('src', 'umath', 'matmul.h.src'),
+             join('src', 'umath', 'matmul.c.src'),
              join('src', 'umath', 'ufunc_object.c'),
-             join('src', 'umath', 'extobj.c'),
-             join('src', 'umath', 'cpuid.c'),
-@@ -902,14 +904,31 @@ def configuration(parent_package='',top_path=None):
-             join('src', 'private', 'ufunc_override.h'),
-             join('src', 'private', 'binop_override.h')] + npymath_sources
+@@ -915,6 +916,20 @@ def configuration(parent_package='',top_path=None):
+             join(codegen_dir, 'generate_ufunc_api.py'),
+             ]
  
-+    npymathc_path = join('build', 'src.%s-%s.%s' % (sysconfig.get_platform(), sys.version_info[0], sys.version_info[1]), 'numpy', 'core', 'src', 'npymath')
 +    if platform.system() == "Windows":
 +        eca = ['/fp:fast=2', '/Qimf-precision=high', '/Qprec-sqrt', '/Qstd=c99']
 +        if sys.version_info < (3, 0):
 +            eca.append('/Qprec-div')
 +    else:
-+        eca = ['-fp-model fast=2', '-fimf-precision=high', '-prec-sqrt']
++        eca = ['-fp-model', 'fast=2', '-fimf-precision=high', '-prec-sqrt']
 +    config.add_library('loops',
 +                       sources=loops_src,
-+                       include_dirs=[npymathc_path],
++                       include_dirs=[],
 +                       extra_compiler_args=eca,
 +                       depends=deps + umath_deps,
++                       macros=getattr(config, 'define_macros', getattr(config.get_distribution(), 'define_macros', []))
 +                       )
 +
-+    mkl_info = get_info('mkl')
-     config.add_extension('umath',
-                          sources=umath_src +
-                                  [generate_config_h,
-                                  generate_numpyconfig_h,
-                                  generate_umath_c,
-                                  generate_ufunc_api],
--                         depends=deps + umath_deps,
--                         libraries=['npymath'],
-+                         include_dirs=[npymathc_path],
-+                         depends=deps + umath_deps + loops_src,
-+                         libraries=['loops', 'npymath'],
-+                         extra_info=mkl_info
-                          )
+     config.add_extension('_multiarray_umath',
+                          sources=multiarray_src + umath_src +
+                                  npymath_sources + common_src +
+@@ -926,9 +941,10 @@ def configuration(parent_package='',top_path=None):
+                                   generate_umath_c,
+                                   generate_ufunc_api,
+                                  ],
++                         extra_compile_args=['/Qstd=c99' if platform.system() == "Windows" else ''],
+                          depends=deps + multiarray_deps + umath_deps +
+                                 common_deps,
+-                         libraries=['npymath', 'npysort'],
++                         libraries=['loops', 'npymath', 'npysort'],
+                          extra_info=extra_info)
  
      #######################################################################
 diff --git a/numpy/core/setup_common.py b/numpy/core/setup_common.py
-index 356482b..9f93b00 100644
+index f837df1..c242e18 100644
 --- a/numpy/core/setup_common.py
 +++ b/numpy/core/setup_common.py
-@@ -101,13 +101,13 @@ def check_api_version(apiversion, codegen_dir):
+@@ -102,13 +102,13 @@ def check_api_version(apiversion, codegen_dir):
                        MismatchCAPIWarning, stacklevel=2)
  # Mandatory functions: if not found, fail the build
  MANDATORY_FUNCS = ["sin", "cos", "tan", "sinh", "cosh", "tanh", "fabs",
@@ -529,8 +516,8 @@ index 356482b..9f93b00 100644
 +        "rint", "trunc", "exp2", "log2", "invsqrt", "hypot", "atan2", "pow",
          "copysign", "nextafter", "ftello", "fseeko",
          "strtoll", "strtoull", "cbrt", "strtold_l", "fallocate",
-         "backtrace"]
-@@ -177,7 +177,7 @@ OPTIONAL_STDFUNCS_MAYBE = [
+         "backtrace", "madvise"]
+@@ -179,7 +179,7 @@ OPTIONAL_STDFUNCS_MAYBE = [
  # C99 functions: float and long double versions
  C99_FUNCS = [
      "sin", "cos", "tan", "sinh", "cosh", "tanh", "fabs", "floor", "ceil",
@@ -539,7 +526,7 @@ index 356482b..9f93b00 100644
      "asin", "acos", "atan", "asinh", "acosh", "atanh", "hypot", "atan2",
      "pow", "fmod", "modf", 'frexp', 'ldexp', "exp2", "log2", "copysign",
      "nextafter", "cbrt"
-@@ -189,7 +189,7 @@ C99_COMPLEX_TYPES = [
+@@ -191,7 +191,7 @@ C99_COMPLEX_TYPES = [
      ]
  C99_COMPLEX_FUNCS = [
      "cabs", "cacos", "cacosh", "carg", "casin", "casinh", "catan",
@@ -627,10 +614,11 @@ index f2e5229..6f919f1 100644
   */
  #ifdef HAVE_@KIND@@C@
  NPY_INPLACE @type@ npy_@kind@@c@(@type@ x)
-@@ -473,6 +473,19 @@ NPY_INPLACE @type@ npy_@kind@@c@(@type@ x)
+@@ -472,6 +472,19 @@ NPY_INPLACE @type@ npy_@kind@@c@(@type@ x)
+ 
  /**end repeat1**/
  
- /**begin repeat1
++/**begin repeat1
 + * #kind = invsqrt#
 + * #KIND = INVSQRT#
 + */
@@ -643,56 +631,54 @@ index f2e5229..6f919f1 100644
 +
 +/**end repeat1**/
 +
-+/**begin repeat1
+ /**begin repeat1
   * #kind = atan2,hypot,pow,fmod,copysign#
   * #KIND = ATAN2,HYPOT,POW,FMOD,COPYSIGN#
-  */
 diff --git a/numpy/core/src/umath/funcs.inc.src b/numpy/core/src/umath/funcs.inc.src
 index da2ab07..45d80ce 100644
 --- a/numpy/core/src/umath/funcs.inc.src
 +++ b/numpy/core/src/umath/funcs.inc.src
-@@ -271,6 +271,13 @@ nc_sqrt@c@(@ctype@ *x, @ctype@ *r)
+@@ -270,6 +270,13 @@ nc_sqrt@c@(@ctype@ *x, @ctype@ *r)
+     return;
  }
  
- static void
++static void
 +nc_invsqrt@c@(@ctype@ *x, @ctype@ *r)
 +{
 +    *r = npy_cinvsqrt@c@(*x);
 +    return;
 +}
 +
-+static void
+ static void
  nc_rint@c@(@ctype@ *x, @ctype@ *r)
  {
-     r->real = npy_rint@c@(x->real);
-@@ -294,6 +301,13 @@ nc_log1p@c@(@ctype@ *x, @ctype@ *r)
+@@ -293,6 +300,13 @@ nc_log1p@c@(@ctype@ *x, @ctype@ *r)
+     return;
  }
  
- static void
++static void
 +nc_erf@c@(@ctype@ *x, @ctype@ *r)
 +{
 +    *r = npy_cerf@c@(*x);
 +    return;
 +}
 +
-+static void
+ static void
  nc_exp@c@(@ctype@ *x, @ctype@ *r)
  {
-     *r = npy_cexp@c@(*x);
 diff --git a/numpy/core/src/umath/loops.c.src b/numpy/core/src/umath/loops.c.src
-index 0b02031..0cc2823 100644
+index ae3ece7..983dbac 100644
 --- a/numpy/core/src/umath/loops.c.src
 +++ b/numpy/core/src/umath/loops.c.src
-@@ -1,5 +1,7 @@
+@@ -1,5 +1,6 @@
  /* -*- c -*- */
 -
 +#include "mkl.h"
-+#include "npy_math.c"
 +#include <fenv.h>
  #define _UMATHMODULE
+ #define _MULTIARRAYMODULE
  #define NPY_NO_DEPRECATED_API NPY_API_VERSION
- 
-@@ -22,14 +24,6 @@
+@@ -20,14 +21,6 @@
  
  #include <string.h> /* for memchr */
  
@@ -707,10 +693,11 @@ index 0b02031..0cc2823 100644
  
  /*
   * largest simd vector size in bytes numpy supports
-@@ -41,13 +35,89 @@
+@@ -38,6 +31,82 @@
+ #define NPY_MAX_SIMD_SIZE 1024
  #endif
  
- /*
++/*
 + * cutoff blocksize for pairwise summation
 + * decreasing it decreases errors slightly as more pairs are summed but
 + * also lowers performance, as the inner loop is unrolled eight times it is
@@ -786,10 +773,10 @@ index 0b02031..0cc2823 100644
 + */
 +#define DISJOINT_OR_SAME(p1, p2, n, s) (((p1) == (p2)) || ((p2) + (n)*(s) < (p1)) || ((p1) + (n)*(s) < (p2)) )
 +
-+/*
+ /*
   * include vectorized functions and dispatchers
   * this file is safe to include also for generic builds
-  * platform specific instructions are either masked via the proprocessor or
+@@ -45,7 +114,7 @@
   * runtime detected
   */
  #include "simd.inc"
@@ -798,7 +785,7 @@ index 0b02031..0cc2823 100644
  
  /*
   *****************************************************************************
-@@ -90,6 +160,21 @@
+@@ -88,6 +157,21 @@
      npy_intp i;\
      for(i = 0; i < n; i++, ip1 += is1, op1 += os1)
  
@@ -820,7 +807,7 @@ index 0b02031..0cc2823 100644
  /*
   * loop with contiguous specialization
   * op should be the code working on `tin in` and
-@@ -796,14 +881,9 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
+@@ -794,14 +878,9 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
  NPY_NO_EXPORT void
  BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
  {
@@ -838,7 +825,7 @@ index 0b02031..0cc2823 100644
      }
  }
  /**end repeat**/
-@@ -970,6 +1050,9 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
+@@ -968,6 +1047,9 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
   * #OP =  >, <#
   **/
  
@@ -848,35 +835,7 @@ index 0b02031..0cc2823 100644
  NPY_NO_EXPORT void
  @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
  {
-@@ -1341,14 +1424,14 @@ NPY_NO_EXPORT void
-         }
-     }
-     if (give_future_warning) {
--        NPY_ALLOW_C_API_DEF
--        NPY_ALLOW_C_API;
-+	NPY_ALLOW_C_API_DEF
-+	NPY_ALLOW_C_API;
-         /* 2016-01-18, 1.11 */
-         if (DEPRECATE_FUTUREWARNING(
-                 "In the future, 'NAT @OP@ x' and 'x @OP@ NAT' "
-                 "will always be False.") < 0) {
--            /* nothing to do, we return anyway */
--        }
-+	    /* nothing to do, we return anyway */
-+	}
-         NPY_DISABLE_C_API;
-     }
- }
-@@ -1374,7 +1457,7 @@ NPY_NO_EXPORT void
-         if (DEPRECATE_FUTUREWARNING(
-                 "In the future, NAT != NAT will be True "
-                 "rather than False.") < 0) {
--            /* nothing to do, we return anyway */
-+	    /* nothing to do, we return anyway */
-         }
-         NPY_DISABLE_C_API;
-     }
-@@ -1632,98 +1715,91 @@ TIMEDELTA_mm_d_divide(char **args, npy_intp *dimensions, npy_intp *steps, void *
+@@ -1629,98 +1711,91 @@ TIMEDELTA_mm_m_remainder(char **args, npy_intp *dimensions, npy_intp *steps, voi
   * Float types
   *  #type = npy_float, npy_double#
   *  #TYPE = FLOAT, DOUBLE#
@@ -1036,7 +995,7 @@ index 0b02031..0cc2823 100644
      }
  }
  
-@@ -1731,113 +1807,1507 @@ pairwise_sum_@TYPE@(char *a, npy_intp n, npy_intp stride)
+@@ -1728,114 +1803,1508 @@ pairwise_sum_@TYPE@(char *a, npy_intp n, npy_intp stride)
  
  /**begin repeat
   * Float types
@@ -1301,6 +1260,7 @@ index 0b02031..0cc2823 100644
 -    BINARY_LOOP {
 -        const @type@ in1 = *(@type@ *)ip1;
 -        const @type@ in2 = *(@type@ *)ip2;
+-        *((@type@ *)op1)= npy_copysign@c@(in1, in2);
 +    if(IS_UNARY_CONT(@type@, @type@) &&
 +           dimensions[0] > VML_TRANSCEDENTAL_THRESHOLD &&
 +           DISJOINT_OR_SAME(args[0], args[1], dimensions[0], sizeof(@type@)) ) {
@@ -2609,10 +2569,11 @@ index 0b02031..0cc2823 100644
 +    BINARY_LOOP {
 +        const @type@ in1 = *(@type@ *)ip1;
 +        const @type@ in2 = *(@type@ *)ip2;
-         *((@type@ *)op1)= npy_copysign@c@(in1, in2);
++        *((@type@ *)op1)= npy_copysign@c@(in1, in2);
      }
  }
-@@ -1946,9 +3416,15 @@ NPY_NO_EXPORT void
+ 
+@@ -1942,9 +3411,15 @@ NPY_NO_EXPORT void
  NPY_NO_EXPORT void
  @TYPE@_square(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data))
  {
@@ -2631,7 +2592,7 @@ index 0b02031..0cc2823 100644
          UNARY_LOOP {
              const @type@ in1 = *(@type@ *)ip1;
              *((@type@ *)op1) = in1*in1;
-@@ -1959,10 +3435,15 @@ NPY_NO_EXPORT void
+@@ -1955,10 +3430,15 @@ NPY_NO_EXPORT void
  NPY_NO_EXPORT void
  @TYPE@_reciprocal(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data))
  {
@@ -2651,7 +2612,7 @@ index 0b02031..0cc2823 100644
          UNARY_LOOP {
              const @type@ in1 = *(@type@ *)ip1;
              *((@type@ *)op1) = 1/in1;
-@@ -1990,7 +3471,15 @@ NPY_NO_EXPORT void
+@@ -1986,7 +3466,15 @@ NPY_NO_EXPORT void
  NPY_NO_EXPORT void
  @TYPE@_absolute(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
  {
@@ -2668,7 +2629,7 @@ index 0b02031..0cc2823 100644
          UNARY_LOOP {
              const @type@ in1 = *(@type@ *)ip1;
              const @type@ tmp = in1 > 0 ? in1 : -in1;
-@@ -2442,9 +3931,18 @@ HALF_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
+@@ -2439,9 +3927,18 @@ HALF_ldexp_long(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
   * #ftype = npy_float, npy_double, npy_longdouble#
   * #c = f, , l#
   * #C = F, , L#
@@ -2687,7 +2648,7 @@ index 0b02031..0cc2823 100644
  static void
  pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_intp n,
                      npy_intp stride)
-@@ -2481,14 +3979,14 @@ pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_intp n,
+@@ -2478,14 +3975,14 @@ pairwise_sum_@TYPE@(@ftype@ *rr, @ftype@ * ri, char * a, npy_intp n,
  
          for (i = 8; i < n - (n % 8); i += 8) {
              /* small blocksizes seems to mess with hardware prefetch */
@@ -2707,7 +2668,7 @@ index 0b02031..0cc2823 100644
              r[7] += *((@ftype@ *)(a + (i + 6) * stride + sizeof(@ftype@)));
          }
  
-@@ -2745,10 +4243,30 @@ NPY_NO_EXPORT void
+@@ -2742,10 +4239,30 @@ NPY_NO_EXPORT void
  NPY_NO_EXPORT void
  @TYPE@_absolute(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
  {
@@ -2742,16 +2703,16 @@ index 0b02031..0cc2823 100644
      }
  }
  
-@@ -2822,6 +4340,7 @@ NPY_NO_EXPORT void
-             ((@ftype@ *)op1)[1] = in2i;
-         }
+@@ -2771,6 +4288,7 @@ NPY_NO_EXPORT void
+                             (CEQ(in1r, in1i, 0.0, 0.0) ?  0 : NPY_NAN@C@));
+         ((@ftype@ *)op1)[1] = 0;
      }
 +    feclearexcept(FE_INVALID);
  }
- /**end repeat1**/
  
+ /**begin repeat1
 diff --git a/numpy/core/src/umath/loops.h.src b/numpy/core/src/umath/loops.h.src
-index 5c2b2c2..ecc2076 100644
+index 9b63273..e939c45 100644
 --- a/numpy/core/src/umath/loops.h.src
 +++ b/numpy/core/src/umath/loops.h.src
 @@ -159,8 +159,16 @@ NPY_NO_EXPORT void
@@ -2773,5 +2734,5 @@ index 5c2b2c2..ecc2076 100644
  
  /**begin repeat
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0009-intel-mkl_mem-all.patch
+++ b/recipe/0009-intel-mkl_mem-all.patch
@@ -1,62 +1,63 @@
-From 09ca8f53f073beba780ae628b6087649954af4c9 Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Thu, 26 Jul 2018 11:50:49 -0500
+From dbfd4b110d7e859a1b466fc4c5fc6d5af804165d Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 10:39:09 +0000
 Subject: [PATCH 09/15] intel mkl_mem all
 
 ---
- numpy/core/include/numpy/ndarraytypes.h            |  40 +++---
- numpy/core/setup.py                                |  32 ++++-
- numpy/core/src/mkl_defs/aligned_alloc.c            | 146 +++++++++++++++++++++
- numpy/core/src/mkl_defs/aligned_alloc.h            |  11 ++
- numpy/core/src/mkl_defs/mkl_cpy.c                  |  86 ++++++++++++
- numpy/core/src/mkl_defs/mkl_cpy.h                  |  10 ++
- numpy/core/src/multiarray/alloc.c                  |  20 +++
- numpy/core/src/multiarray/array_assign_scalar.c    |   1 +
- numpy/core/src/multiarray/arrayobject.c            |   2 +
- numpy/core/src/multiarray/arraytypes.c.src         |   1 +
- numpy/core/src/multiarray/compiled_base.c          |   2 +
- numpy/core/src/multiarray/convert.c                |   1 +
- numpy/core/src/multiarray/convert_datatype.c       |   1 +
- numpy/core/src/multiarray/datetime.c               |   2 +
- numpy/core/src/multiarray/datetime_busday.c        |   1 +
- numpy/core/src/multiarray/datetime_busdaycal.c     |   2 +
- numpy/core/src/multiarray/datetime_strings.c       |   1 +
- numpy/core/src/multiarray/descriptor.c             |   2 +
- numpy/core/src/multiarray/dtype_transfer.c         |   2 +
- numpy/core/src/multiarray/einsum.c.src             |   2 +
- numpy/core/src/multiarray/flagsobject.c            |   1 +
- numpy/core/src/multiarray/getset.c                 |   2 +
- numpy/core/src/multiarray/item_selection.c         |   2 +
- numpy/core/src/multiarray/iterators.c              |   2 +
- .../src/multiarray/lowlevel_strided_loops.c.src    |   1 +
- numpy/core/src/multiarray/mapping.c                |   1 +
- numpy/core/src/multiarray/methods.c                |   1 +
- numpy/core/src/multiarray/multiarraymodule.c       |   1 +
- numpy/core/src/multiarray/nditer_api.c             |   2 +
- numpy/core/src/multiarray/nditer_constr.c          |   2 +
- numpy/core/src/multiarray/nditer_templ.c.src       |   1 +
- numpy/core/src/multiarray/numpyos.c                |   1 +
- numpy/core/src/multiarray/scalarapi.c              |   1 +
- numpy/core/src/multiarray/scalartypes.c.src        |   2 +
- numpy/core/src/multiarray/sequence.c               |   1 +
- numpy/core/src/multiarray/shape.c                  |   1 +
- numpy/core/src/multiarray/ucsnarrow.c              |   1 +
- numpy/core/src/npysort/npysort_common.h            |   1 +
- numpy/core/src/umath/_rational_tests.c.src         |   1 +
- numpy/core/src/umath/reduction.c                   |   1 +
- numpy/core/src/umath/simd.inc.src                  |   1 +
- numpy/core/src/umath/ufunc_object.c                |   2 +
- numpy/core/src/umath/ufunc_type_resolution.c       |   2 +
- numpy/core/src/umath/umathmodule.c                 |   2 +
- numpy/random/setup.py                              |   4 +-
- 45 files changed, 379 insertions(+), 23 deletions(-)
+ numpy/core/include/numpy/ndarraytypes.h       |  40 ++---
+ numpy/core/setup.py                           |  26 ++-
+ numpy/core/src/common/numpyos.c               |   1 +
+ numpy/core/src/common/ucsnarrow.c             |   1 +
+ numpy/core/src/mkl_defs/aligned_alloc.c       | 149 ++++++++++++++++++
+ numpy/core/src/mkl_defs/aligned_alloc.h       |  11 ++
+ numpy/core/src/mkl_defs/mkl_cpy.c             |  86 ++++++++++
+ numpy/core/src/mkl_defs/mkl_cpy.h             |  10 ++
+ numpy/core/src/multiarray/alloc.c             |  20 +++
+ .../core/src/multiarray/array_assign_scalar.c |   1 +
+ numpy/core/src/multiarray/arrayobject.c       |   2 +
+ numpy/core/src/multiarray/arraytypes.c.src    |   2 +
+ numpy/core/src/multiarray/compiled_base.c     |   2 +
+ numpy/core/src/multiarray/convert.c           |   1 +
+ numpy/core/src/multiarray/convert_datatype.c  |   1 +
+ numpy/core/src/multiarray/datetime.c          |   2 +
+ numpy/core/src/multiarray/datetime_busday.c   |   1 +
+ .../core/src/multiarray/datetime_busdaycal.c  |   2 +
+ numpy/core/src/multiarray/datetime_strings.c  |   1 +
+ numpy/core/src/multiarray/descriptor.c        |   2 +
+ numpy/core/src/multiarray/dtype_transfer.c    |   2 +
+ numpy/core/src/multiarray/einsum.c.src        |   2 +
+ numpy/core/src/multiarray/flagsobject.c       |   1 +
+ numpy/core/src/multiarray/getset.c            |   2 +
+ numpy/core/src/multiarray/item_selection.c    |  32 +++-
+ numpy/core/src/multiarray/iterators.c         |   2 +
+ .../multiarray/lowlevel_strided_loops.c.src   |   1 +
+ numpy/core/src/multiarray/mapping.c           |   1 +
+ numpy/core/src/multiarray/methods.c           |   1 +
+ numpy/core/src/multiarray/multiarraymodule.c  |   1 +
+ numpy/core/src/multiarray/nditer_api.c        |   2 +
+ numpy/core/src/multiarray/nditer_constr.c     |   2 +
+ numpy/core/src/multiarray/nditer_templ.c.src  |   1 +
+ numpy/core/src/multiarray/scalarapi.c         |   1 +
+ numpy/core/src/multiarray/scalartypes.c.src   |   2 +
+ numpy/core/src/multiarray/sequence.c          |   1 +
+ numpy/core/src/multiarray/shape.c             |   1 +
+ numpy/core/src/npysort/npysort_common.h       |   1 +
+ numpy/core/src/umath/_rational_tests.c.src    |   1 +
+ numpy/core/src/umath/reduction.c              |   1 +
+ numpy/core/src/umath/simd.inc.src             |   1 +
+ numpy/core/src/umath/ufunc_object.c           |   2 +
+ numpy/core/src/umath/ufunc_type_resolution.c  |   2 +
+ numpy/core/src/umath/umathmodule.c            |   2 +
+ numpy/core/tests/test_regression.py           |  11 ++
+ numpy/random/setup.py                         |   4 +-
+ 46 files changed, 411 insertions(+), 30 deletions(-)
  create mode 100644 numpy/core/src/mkl_defs/aligned_alloc.c
  create mode 100644 numpy/core/src/mkl_defs/aligned_alloc.h
  create mode 100644 numpy/core/src/mkl_defs/mkl_cpy.c
  create mode 100644 numpy/core/src/mkl_defs/mkl_cpy.h
 
 diff --git a/numpy/core/include/numpy/ndarraytypes.h b/numpy/core/include/numpy/ndarraytypes.h
-index cf73cec..053ab42 100644
+index b0b749c..9eeb5f9 100644
 --- a/numpy/core/include/numpy/ndarraytypes.h
 +++ b/numpy/core/include/numpy/ndarraytypes.h
 @@ -345,25 +345,27 @@ struct NpyAuxData_tag {
@@ -107,10 +108,10 @@ index cf73cec..053ab42 100644
  
  /* Dimensions and strides */
 diff --git a/numpy/core/setup.py b/numpy/core/setup.py
-index 5feb851..2d35844 100644
+index fb0386e..486319e 100644
 --- a/numpy/core/setup.py
 +++ b/numpy/core/setup.py
-@@ -613,6 +613,7 @@ def configuration(parent_package='',top_path=None):
+@@ -614,6 +614,7 @@ def configuration(parent_package='',top_path=None):
      config.add_include_dirs(join('src', 'multiarray'))
      config.add_include_dirs(join('src', 'umath'))
      config.add_include_dirs(join('src', 'npysort'))
@@ -118,28 +119,11 @@ index 5feb851..2d35844 100644
  
      config.add_define_macros([("NPY_INTERNAL_BUILD", "1")]) # this macro indicates that Numpy build is in process
      config.add_define_macros([("HAVE_NPY_CONFIG_H", "1")])
-@@ -694,6 +695,17 @@ def configuration(parent_package='',top_path=None):
-             subst_dict)
- 
-     #######################################################################
-+    #                         aligned_alloc library                       #
-+    #######################################################################
-+
-+    # This library is created for the build but it is not installed
-+    aligned_alloc_sources = [join('src', 'mkl_defs', 'aligned_alloc.h'),
-+                       join('src', 'mkl_defs', 'aligned_alloc.c')]
-+    config.add_library('aligned_alloc',
-+                       sources=aligned_alloc_sources,
-+                       include_dirs=[])
-+
-+    #######################################################################
-     #                         npysort library                             #
-     #######################################################################
- 
-@@ -711,6 +723,17 @@ def configuration(parent_package='',top_path=None):
+@@ -712,6 +713,17 @@ def configuration(parent_package='',top_path=None):
+                        sources=npysort_sources,
                         include_dirs=[])
  
-     #######################################################################
++    #######################################################################
 +    #                         mkl_cp library                              #
 +    #######################################################################
 +
@@ -150,46 +134,77 @@ index 5feb851..2d35844 100644
 +                       sources=mkl_cp_sources,
 +                       include_dirs=[])
 +
-+    #######################################################################
-     #                        multiarray module                            #
      #######################################################################
+     #                     multiarray_tests module                         #
+     #######################################################################
+@@ -869,6 +881,11 @@ def configuration(parent_package='',top_path=None):
+             join('src', 'multiarray', 'vdot.c'),
+             ]
  
-@@ -851,7 +874,7 @@ def configuration(parent_package='',top_path=None):
-                                   join('*.py')],
++    aligned_alloc_sources = [
++        join('src', 'mkl_defs', 'aligned_alloc.h'),
++        join('src', 'mkl_defs', 'aligned_alloc.c')
++    ]
++
+     #######################################################################
+     #             _multiarray_umath module - umath part                   #
+     #######################################################################
+@@ -940,11 +957,11 @@ def configuration(parent_package='',top_path=None):
+                                   join('*.py'),
+                                   generate_umath_c,
+                                   generate_ufunc_api,
+-                                 ],
++                                 ] + aligned_alloc_sources,
                           extra_compile_args=['/Qstd=c99' if platform.system() == "Windows" else ''],
-                          depends=deps + multiarray_deps,
--                         libraries=['npymath', 'npysort'],
-+                         libraries=['npymath', 'npysort', 'aligned_alloc', 'mkl_cp'],
-                          extra_info=get_info('mkl'))
+                          depends=deps + multiarray_deps + umath_deps +
+                                 common_deps,
+-                         libraries=['loops', 'npymath', 'npysort'],
++                         libraries=['loops', 'npymath', 'npysort', 'mkl_cp'],
+                          extra_info=extra_info)
  
      #######################################################################
-@@ -927,7 +950,7 @@ def configuration(parent_package='',top_path=None):
-                                  generate_ufunc_api],
-                          include_dirs=[npymathc_path],
-                          depends=deps + umath_deps + loops_src,
--                         libraries=['loops', 'npymath'],
-+                         libraries=['loops', 'npymath', 'aligned_alloc', 'mkl_cp'],
-                          extra_info=mkl_info
-                          )
- 
-@@ -943,7 +966,10 @@ def configuration(parent_package='',top_path=None):
+@@ -959,7 +976,10 @@ def configuration(parent_package='',top_path=None):
      #######################################################################
  
      config.add_extension('_rational_tests',
 -                    sources=[join('src', 'umath', '_rational_tests.c.src')])
 +                    sources=[join('src', 'umath', '_rational_tests.c.src')],
 +                    libraries=['mkl_cp'],
-+                    extra_info=mkl_info
++                    extra_info=extra_info
 +                    )
  
      #######################################################################
      #                        struct_ufunc_test module                     #
+diff --git a/numpy/core/src/common/numpyos.c b/numpy/core/src/common/numpyos.c
+index d60b1ca..8decd18 100644
+--- a/numpy/core/src/common/numpyos.c
++++ b/numpy/core/src/common/numpyos.c
+@@ -25,6 +25,7 @@
+ #endif
+ 
+ 
++#include "mkl_cpy.h"
+ 
+ /*
+  * From the C99 standard, section 7.19.6: The exponent always contains at least
+diff --git a/numpy/core/src/common/ucsnarrow.c b/numpy/core/src/common/ucsnarrow.c
+index 8e293e9..0d902b9 100644
+--- a/numpy/core/src/common/ucsnarrow.c
++++ b/numpy/core/src/common/ucsnarrow.c
+@@ -14,6 +14,7 @@
+ 
+ #include "npy_pycompat.h"
+ #include "ctors.h"
++#include "mkl_cpy.h"
+ 
+ /*
+  * Functions only needed on narrow builds of Python for converting back and
 diff --git a/numpy/core/src/mkl_defs/aligned_alloc.c b/numpy/core/src/mkl_defs/aligned_alloc.c
 new file mode 100644
-index 0000000..667432d
+index 0000000..81e9e33
 --- /dev/null
 +++ b/numpy/core/src/mkl_defs/aligned_alloc.c
-@@ -0,0 +1,146 @@
+@@ -0,0 +1,149 @@
 +#include "mkl.h"
 +#include <stdlib.h>
 +#include <stddef.h>
@@ -205,6 +220,9 @@ index 0000000..667432d
 +#define __8BYTES_ALIGNMENT_OFFSET(ptr) (((size_t) (ptr)) & 0x7)
 +#define MKL_INT_MAX ((size_t) (~((MKL_UINT) 0) >> 1))
 +
++#if defined(_MSC_VER)
++#define posix_memalign(p, a, s) (((*(p)) = _aligned_malloc((s), (a))), *(p) ?0 :errno)
++#endif
 +static int is_tbb_enabled(void) {
 +    static int TBB_ENABLED = -1;
 +    if (TBB_ENABLED == -1) {
@@ -229,7 +247,7 @@ index 0000000..667432d
 +   }
 +}
 +
-+inline void *_aligned_alloc(size_t size) {
++void * _aligned_alloc(size_t size) {
 +    /* Only available for Linux and OSX (has been explicitly disabled on Windows : see aligned_alloc.h)
 +     * With Windows, we would run into composability issues with modules like h5py which allocate
 +     * memory using libc functions in another library, like hdf5 for instance
@@ -245,7 +263,7 @@ index 0000000..667432d
 +
 +
 +#ifdef WITH_ALIGNED_CALLOC
-+inline void *_aligned_calloc(size_t nelem, size_t elsize)
++void * _aligned_calloc(size_t nelem, size_t elsize)
 +{
 +    size_t size = nelem * elsize;
 +    void *data = _aligned_alloc(size);
@@ -286,7 +304,7 @@ index 0000000..667432d
 +}
 +#endif
 +
-+inline void* call_aligned_malloc(size_t size) {
++void* call_aligned_malloc(size_t size) {
 +#if PY_VERSION_HEX >= 0x03040000
 +    if(is_tracemalloc_enabled()){
 +        return PyMem_RawMalloc(size);
@@ -297,7 +315,7 @@ index 0000000..667432d
 +    }
 +}
 +
-+inline void* call_aligned_realloc(void* input, size_t size) {
++void* call_aligned_realloc(void* input, size_t size) {
 +#if PY_VERSION_HEX >= 0x03040000
 +    if(is_tracemalloc_enabled()){
 +        return PyMem_RawRealloc(input, size);
@@ -311,7 +329,7 @@ index 0000000..667432d
 +    }
 +}
 +
-+inline void* call_aligned_calloc(size_t num, size_t size) {
++void* call_aligned_calloc(size_t num, size_t size) {
 +#if PY_VERSION_HEX >= 0x03040000
 +    if(is_tracemalloc_enabled()){
 +        return PyMem_RawCalloc(num, size);
@@ -326,7 +344,7 @@ index 0000000..667432d
 +    }
 +}
 +
-+inline void call_free(void* ptr) {
++void call_free(void* ptr) {
 +#if PY_VERSION_HEX >= 0x03040000
 +    if(is_tracemalloc_enabled()){
 +        PyMem_RawFree(ptr);
@@ -462,7 +480,7 @@ index 0000000..74af118
 +#   endif
 +#endif
 diff --git a/numpy/core/src/multiarray/alloc.c b/numpy/core/src/multiarray/alloc.c
-index fe957bf..88d1135 100644
+index 6755095..6e84e81 100644
 --- a/numpy/core/src/multiarray/alloc.c
 +++ b/numpy/core/src/multiarray/alloc.c
 @@ -1,6 +1,7 @@
@@ -473,15 +491,15 @@ index fe957bf..88d1135 100644
  
  #if PY_VERSION_HEX >= 0x03060000
  #include <pymem.h>
-@@ -75,6 +76,7 @@ _npy_alloc_cache(npy_uintp nelem, npy_uintp esz, npy_uint msz,
- #endif
+@@ -86,6 +87,7 @@ _npy_alloc_cache(npy_uintp nelem, npy_uintp esz, npy_uint msz,
+     return p;
  }
  
 +
  /*
   * return pointer p to cache, nelem is number of elements of the cache bucket
   * size (1 or sizeof(npy_intp)) of the block pointed too
-@@ -142,6 +144,7 @@ npy_alloc_cache_dim(npy_uintp sz)
+@@ -153,6 +155,7 @@ npy_alloc_cache_dim(npy_uintp sz)
      if (sz < 2) {
          sz = 2;
      }
@@ -489,7 +507,7 @@ index fe957bf..88d1135 100644
      return _npy_alloc_cache(sz, sizeof(npy_intp), NBUCKETS_DIM, dimcache,
                              &PyArray_malloc);
  }
-@@ -153,6 +156,7 @@ npy_free_cache_dim(void * p, npy_uintp sz)
+@@ -164,6 +167,7 @@ npy_free_cache_dim(void * p, npy_uintp sz)
      if (sz < 2) {
          sz = 2;
      }
@@ -497,7 +515,7 @@ index fe957bf..88d1135 100644
      _npy_free_cache(p, sz, NBUCKETS_DIM, dimcache,
                      &PyArray_free);
  }
-@@ -207,7 +211,11 @@ PyDataMem_NEW(size_t size)
+@@ -218,7 +222,11 @@ PyDataMem_NEW(size_t size)
  {
      void *result;
  
@@ -509,7 +527,7 @@ index fe957bf..88d1135 100644
      if (_PyDataMem_eventhook != NULL) {
          NPY_ALLOW_C_API_DEF
          NPY_ALLOW_C_API
-@@ -229,7 +237,11 @@ PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
+@@ -240,7 +248,11 @@ PyDataMem_NEW_ZEROED(size_t size, size_t elsize)
  {
      void *result;
  
@@ -521,7 +539,7 @@ index fe957bf..88d1135 100644
      if (_PyDataMem_eventhook != NULL) {
          NPY_ALLOW_C_API_DEF
          NPY_ALLOW_C_API
-@@ -250,7 +262,11 @@ NPY_NO_EXPORT void
+@@ -261,7 +273,11 @@ NPY_NO_EXPORT void
  PyDataMem_FREE(void *ptr)
  {
      PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
@@ -533,7 +551,7 @@ index fe957bf..88d1135 100644
      if (_PyDataMem_eventhook != NULL) {
          NPY_ALLOW_C_API_DEF
          NPY_ALLOW_C_API
-@@ -270,7 +286,11 @@ PyDataMem_RENEW(void *ptr, size_t size)
+@@ -281,7 +297,11 @@ PyDataMem_RENEW(void *ptr, size_t size)
  {
      void *result;
  
@@ -546,7 +564,7 @@ index fe957bf..88d1135 100644
          PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
      }
 diff --git a/numpy/core/src/multiarray/array_assign_scalar.c b/numpy/core/src/multiarray/array_assign_scalar.c
-index 17de99c..3fd57e1 100644
+index ecb5be4..6995bbf 100644
 --- a/numpy/core/src/multiarray/array_assign_scalar.c
 +++ b/numpy/core/src/multiarray/array_assign_scalar.c
 @@ -9,6 +9,7 @@
@@ -558,7 +576,7 @@ index 17de99c..3fd57e1 100644
  #define NPY_NO_DEPRECATED_API NPY_API_VERSION
  #define _MULTIARRAYMODULE
 diff --git a/numpy/core/src/multiarray/arrayobject.c b/numpy/core/src/multiarray/arrayobject.c
-index 8ba3f53..4d18ffa 100644
+index 97aaee9..b5a8215 100644
 --- a/numpy/core/src/multiarray/arrayobject.c
 +++ b/numpy/core/src/multiarray/arrayobject.c
 @@ -23,6 +23,7 @@ maintainer email:  oliphant.travis@ieee.org
@@ -578,7 +596,7 @@ index 8ba3f53..4d18ffa 100644
  
  #include "binop_override.h"
 diff --git a/numpy/core/src/multiarray/arraytypes.c.src b/numpy/core/src/multiarray/arraytypes.c.src
-index 553737a..133e5d8 100644
+index 823ee71..7f2439d 100644
 --- a/numpy/core/src/multiarray/arraytypes.c.src
 +++ b/numpy/core/src/multiarray/arraytypes.c.src
 @@ -9,6 +9,7 @@
@@ -589,8 +607,16 @@ index 553737a..133e5d8 100644
  #include "numpy/npy_common.h"
  #include "numpy/arrayobject.h"
  #include "numpy/arrayscalars.h"
+@@ -1971,6 +1972,7 @@ static void
+ 
+ /**end repeat**/
+ 
++
+ /**begin repeat
+  *
+  * #fname = BOOL,
 diff --git a/numpy/core/src/multiarray/compiled_base.c b/numpy/core/src/multiarray/compiled_base.c
-index bcb44f6..7b8390a 100644
+index 10e3478..bacf99d 100644
 --- a/numpy/core/src/multiarray/compiled_base.c
 +++ b/numpy/core/src/multiarray/compiled_base.c
 @@ -2,12 +2,14 @@
@@ -609,7 +635,7 @@ index bcb44f6..7b8390a 100644
  #include "lowlevel_strided_loops.h" /* for npy_bswap8 */
  #include "alloc.h"
 diff --git a/numpy/core/src/multiarray/convert.c b/numpy/core/src/multiarray/convert.c
-index e88582a..6c66a51 100644
+index 7db4673..354e1da 100644
 --- a/numpy/core/src/multiarray/convert.c
 +++ b/numpy/core/src/multiarray/convert.c
 @@ -22,6 +22,7 @@
@@ -621,7 +647,7 @@ index e88582a..6c66a51 100644
  int
  fallocate(int fd, int mode, off_t offset, off_t len);
 diff --git a/numpy/core/src/multiarray/convert_datatype.c b/numpy/core/src/multiarray/convert_datatype.c
-index 3df764a..818b1cc 100644
+index 33a7064..6a374aa 100644
 --- a/numpy/core/src/multiarray/convert_datatype.c
 +++ b/numpy/core/src/multiarray/convert_datatype.c
 @@ -19,6 +19,7 @@
@@ -633,7 +659,7 @@ index 3df764a..818b1cc 100644
  
  /*
 diff --git a/numpy/core/src/multiarray/datetime.c b/numpy/core/src/multiarray/datetime.c
-index df9b9ce..56d474b 100644
+index a8550d9..82e874e 100644
 --- a/numpy/core/src/multiarray/datetime.c
 +++ b/numpy/core/src/multiarray/datetime.c
 @@ -15,6 +15,7 @@
@@ -685,7 +711,7 @@ index 7a26868..561133c 100644
  NPY_NO_EXPORT int
  PyArray_WeekMaskConverter(PyObject *weekmask_in, npy_bool *weekmask)
 diff --git a/numpy/core/src/multiarray/datetime_strings.c b/numpy/core/src/multiarray/datetime_strings.c
-index 4f9d8fa..948ab21 100644
+index 95b7bb3..9c135cb 100644
 --- a/numpy/core/src/multiarray/datetime_strings.c
 +++ b/numpy/core/src/multiarray/datetime_strings.c
 @@ -23,6 +23,7 @@
@@ -697,7 +723,7 @@ index 4f9d8fa..948ab21 100644
  /*
   * Platform-specific time_t typedef. Some platforms use 32 bit, some use 64 bit
 diff --git a/numpy/core/src/multiarray/descriptor.c b/numpy/core/src/multiarray/descriptor.c
-index e3a0183..0db5089 100644
+index 3038e4d..a32254d 100644
 --- a/numpy/core/src/multiarray/descriptor.c
 +++ b/numpy/core/src/multiarray/descriptor.c
 @@ -6,6 +6,7 @@
@@ -717,7 +743,7 @@ index e3a0183..0db5089 100644
  #include "assert.h"
  #include "buffer.h"
 diff --git a/numpy/core/src/multiarray/dtype_transfer.c b/numpy/core/src/multiarray/dtype_transfer.c
-index 2cb1e0a..13d636f 100644
+index 63b1ead..a2d5769 100644
 --- a/numpy/core/src/multiarray/dtype_transfer.c
 +++ b/numpy/core/src/multiarray/dtype_transfer.c
 @@ -13,6 +13,7 @@
@@ -728,7 +754,7 @@ index 2cb1e0a..13d636f 100644
  
  #define NPY_NO_DEPRECATED_API NPY_API_VERSION
  #define _MULTIARRAYMODULE
-@@ -29,6 +30,7 @@
+@@ -30,6 +31,7 @@
  
  #include "shape.h"
  #include "lowlevel_strided_loops.h"
@@ -750,11 +776,11 @@ index 1765982..d8bf721 100644
  
  /********** PRINTF DEBUG TRACING **************/
 diff --git a/numpy/core/src/multiarray/flagsobject.c b/numpy/core/src/multiarray/flagsobject.c
-index a78bedc..4b19255 100644
+index 85ea49f..bbd2c61 100644
 --- a/numpy/core/src/multiarray/flagsobject.c
 +++ b/numpy/core/src/multiarray/flagsobject.c
-@@ -14,6 +14,7 @@
- #include "npy_pycompat.h"
+@@ -15,6 +15,7 @@
+ #include "array_assign.h"
  
  #include "common.h"
 +#include "mkl_cpy.h"
@@ -782,7 +808,7 @@ index 24962da..0e1b84a 100644
  #include "buffer.h"
  
 diff --git a/numpy/core/src/multiarray/item_selection.c b/numpy/core/src/multiarray/item_selection.c
-index 9255857..fe9d4c5 100644
+index a7c6b14..7c72d49 100644
 --- a/numpy/core/src/multiarray/item_selection.c
 +++ b/numpy/core/src/multiarray/item_selection.c
 @@ -4,6 +4,7 @@
@@ -793,16 +819,56 @@ index 9255857..fe9d4c5 100644
  #include "numpy/arrayobject.h"
  #include "numpy/arrayscalars.h"
  
-@@ -24,6 +25,7 @@
+@@ -25,8 +26,11 @@
  #include "npy_sort.h"
  #include "npy_partition.h"
  #include "npy_binsearch.h"
-+#include "mkl_cpy.h"
++#include "mkl_cpy.c"
  #include "alloc.h"
  
++#define memmove(src, dst, size) call_mkl_mv(src, dst, size, __FILE__, __func__, __LINE__)
++
  /*NUMPY_API
+  * Take
+  */
+@@ -626,14 +630,28 @@ PyArray_Repeat(PyArrayObject *aop, PyObject *op, int axis)
+     for (i = 0; i < axis; i++) {
+         n_outer *= PyArray_DIMS(aop)[i];
+     }
+-    for (i = 0; i < n_outer; i++) {
+-        for (j = 0; j < n; j++) {
+-            npy_intp tmp = broadcast ? counts[0] : counts[j];
+-            for (k = 0; k < tmp; k++) {
+-                memcpy(new_data, old_data, chunk);
+-                new_data += chunk;
++    
++    if(chunk > __THRESHOLD) {
++        for (i = 0; i < n_outer; i++) {
++            for (j = 0; j < n; j++) {
++                npy_intp tmp = broadcast ? counts[0] : counts[j];
++                for (k = 0; k < tmp; k++) {
++                    call_mkl_cpy(new_data, old_data, chunk, __FILE__, __func__, __LINE__);
++                    new_data += chunk;
++                }
++                old_data += chunk;
++            }
++        }
++    } else {
++        for (i = 0; i < n_outer; i++) {
++            for (j = 0; j < n; j++) {
++                npy_intp tmp = broadcast ? counts[0] : counts[j];
++                for (k = 0; k < tmp; k++) {
++                    memcpy(new_data, old_data, chunk);
++                    new_data += chunk;
++                }
++                old_data += chunk;
+             }
+-            old_data += chunk;
+         }
+     }
+ 
 diff --git a/numpy/core/src/multiarray/iterators.c b/numpy/core/src/multiarray/iterators.c
-index 3e3248f..dc1b839 100644
+index a3bc8e7..cdbf482 100644
 --- a/numpy/core/src/multiarray/iterators.c
 +++ b/numpy/core/src/multiarray/iterators.c
 @@ -4,6 +4,7 @@
@@ -822,19 +888,19 @@ index 3e3248f..dc1b839 100644
  #define NEWAXIS_INDEX -1
  #define ELLIPSIS_INDEX -2
 diff --git a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
-index fa68af1..78d98d5 100644
+index 16bacf1..85c498b 100644
 --- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
 +++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
-@@ -17,6 +17,7 @@
+@@ -16,6 +16,7 @@
  #include <numpy/arrayobject.h>
  #include <numpy/npy_cpu.h>
  #include <numpy/halffloat.h>
 +#include "mkl_cpy.h"
  
  #include "lowlevel_strided_loops.h"
- 
+ #include "array_assign.h"
 diff --git a/numpy/core/src/multiarray/mapping.c b/numpy/core/src/multiarray/mapping.c
-index 57b8f15..391502f 100644
+index 17edd2b..c436e1f 100644
 --- a/numpy/core/src/multiarray/mapping.c
 +++ b/numpy/core/src/multiarray/mapping.c
 @@ -1,6 +1,7 @@
@@ -846,11 +912,11 @@ index 57b8f15..391502f 100644
  /*#include <stdio.h>*/
  #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 diff --git a/numpy/core/src/multiarray/methods.c b/numpy/core/src/multiarray/methods.c
-index d6f2577..5f8db62 100644
+index 7c814e6..e14a73c 100644
 --- a/numpy/core/src/multiarray/methods.c
 +++ b/numpy/core/src/multiarray/methods.c
-@@ -23,6 +23,7 @@
- #include "strfuncs.h"
+@@ -24,6 +24,7 @@
+ #include "array_assign.h"
  
  #include "methods.h"
 +#include "mkl_cpy.h"
@@ -858,7 +924,7 @@ index d6f2577..5f8db62 100644
  
  
 diff --git a/numpy/core/src/multiarray/multiarraymodule.c b/numpy/core/src/multiarray/multiarraymodule.c
-index fe19cc9..27a4765 100644
+index 8135769..5a0fa59 100644
 --- a/numpy/core/src/multiarray/multiarraymodule.c
 +++ b/numpy/core/src/multiarray/multiarraymodule.c
 @@ -17,6 +17,7 @@
@@ -868,7 +934,7 @@ index fe19cc9..27a4765 100644
 +#include "aligned_alloc.h"
  
  #define NPY_NO_DEPRECATED_API NPY_API_VERSION
- #define _MULTIARRAYMODULE
+ #define _UMATHMODULE
 diff --git a/numpy/core/src/multiarray/nditer_api.c b/numpy/core/src/multiarray/nditer_api.c
 index 7a33ac0..ce0090f 100644
 --- a/numpy/core/src/multiarray/nditer_api.c
@@ -886,7 +952,7 @@ index 7a33ac0..ce0090f 100644
  /* Internal helper functions private to this file */
  static npy_intp
 diff --git a/numpy/core/src/multiarray/nditer_constr.c b/numpy/core/src/multiarray/nditer_constr.c
-index c56376f..599faee 100644
+index 90cff40..1472e8e 100644
 --- a/numpy/core/src/multiarray/nditer_constr.c
 +++ b/numpy/core/src/multiarray/nditer_constr.c
 @@ -13,11 +13,13 @@
@@ -898,11 +964,11 @@ index c56376f..599faee 100644
  
  #include "arrayobject.h"
  #include "templ_common.h"
- #include "mem_overlap.h"
+ #include "array_assign.h"
 +#include "mkl_cpy.h"
  
- 
  /* Internal helper functions private to this file */
+ static int
 diff --git a/numpy/core/src/multiarray/nditer_templ.c.src b/numpy/core/src/multiarray/nditer_templ.c.src
 index 0f0d599..e143fd6 100644
 --- a/numpy/core/src/multiarray/nditer_templ.c.src
@@ -915,20 +981,8 @@ index 0f0d599..e143fd6 100644
  
  /* SPECIALIZED iternext functions that handle the non-buffering part */
  
-diff --git a/numpy/core/src/multiarray/numpyos.c b/numpy/core/src/multiarray/numpyos.c
-index 52dcbf3..b097d77 100644
---- a/numpy/core/src/multiarray/numpyos.c
-+++ b/numpy/core/src/multiarray/numpyos.c
-@@ -25,6 +25,7 @@
- #endif
- 
- 
-+#include "mkl_cpy.h"
- 
- /*
-  * From the C99 standard, section 7.19.6: The exponent always contains at least
 diff --git a/numpy/core/src/multiarray/scalarapi.c b/numpy/core/src/multiarray/scalarapi.c
-index 5ef6c0b..f073919 100644
+index bc435d1..deab1af 100644
 --- a/numpy/core/src/multiarray/scalarapi.c
 +++ b/numpy/core/src/multiarray/scalarapi.c
 @@ -18,6 +18,7 @@
@@ -940,7 +994,7 @@ index 5ef6c0b..f073919 100644
  static PyArray_Descr *
  _descr_from_subtype(PyObject *type)
 diff --git a/numpy/core/src/multiarray/scalartypes.c.src b/numpy/core/src/multiarray/scalartypes.c.src
-index 0d7db2d..b77627d 100644
+index 2f71c8a..c08c9ea 100644
 --- a/numpy/core/src/multiarray/scalartypes.c.src
 +++ b/numpy/core/src/multiarray/scalartypes.c.src
 @@ -8,6 +8,7 @@
@@ -972,7 +1026,7 @@ index 4769bda..e5415e3 100644
  /*************************************************************************
   ****************   Implement Sequence Protocol **************************
 diff --git a/numpy/core/src/multiarray/shape.c b/numpy/core/src/multiarray/shape.c
-index 3ac71e2..779b598 100644
+index 3082073..7422173 100644
 --- a/numpy/core/src/multiarray/shape.c
 +++ b/numpy/core/src/multiarray/shape.c
 @@ -16,6 +16,7 @@
@@ -983,18 +1037,6 @@ index 3ac71e2..779b598 100644
  
  #include "multiarraymodule.h" /* for interned strings */
  #include "templ_common.h" /* for npy_mul_with_overflow_intp */
-diff --git a/numpy/core/src/multiarray/ucsnarrow.c b/numpy/core/src/multiarray/ucsnarrow.c
-index 8e293e9..0d902b9 100644
---- a/numpy/core/src/multiarray/ucsnarrow.c
-+++ b/numpy/core/src/multiarray/ucsnarrow.c
-@@ -14,6 +14,7 @@
- 
- #include "npy_pycompat.h"
- #include "ctors.h"
-+#include "mkl_cpy.h"
- 
- /*
-  * Functions only needed on narrow builds of Python for converting back and
 diff --git a/numpy/core/src/npysort/npysort_common.h b/numpy/core/src/npysort/npysort_common.h
 index a22045b..17c649a 100644
 --- a/numpy/core/src/npysort/npysort_common.h
@@ -1020,10 +1062,10 @@ index 9e74845..f98a0ad 100644
  #include "common.h"  /* for error_converting */
  
 diff --git a/numpy/core/src/umath/reduction.c b/numpy/core/src/umath/reduction.c
-index 8136d7b..45c6c20 100644
+index 6d04ce3..eb12b4e 100644
 --- a/numpy/core/src/umath/reduction.c
 +++ b/numpy/core/src/umath/reduction.c
-@@ -25,6 +25,7 @@
+@@ -23,6 +23,7 @@
  #include "lowlevel_strided_loops.h"
  #include "reduction.h"
  #include "extobj.h"  /* for _check_ufunc_fperr */
@@ -1032,22 +1074,22 @@ index 8136d7b..45c6c20 100644
  /*
   * Allocates a result array for a reduction operation, with
 diff --git a/numpy/core/src/umath/simd.inc.src b/numpy/core/src/umath/simd.inc.src
-index 5c0568c..4e1af70 100644
+index 4bb8569..114a98b 100644
 --- a/numpy/core/src/umath/simd.inc.src
 +++ b/numpy/core/src/umath/simd.inc.src
-@@ -33,6 +33,7 @@
+@@ -31,6 +31,7 @@
  #include <stdlib.h>
  #include <float.h>
  #include <string.h> /* for memcpy */
 +#include "mkl_cpy.h"
  
- static NPY_INLINE npy_uintp
- abs_ptrdiff(char *a, char *b)
+ #define VECTOR_SIZE_BYTES 16
+ 
 diff --git a/numpy/core/src/umath/ufunc_object.c b/numpy/core/src/umath/ufunc_object.c
-index 59fc5aa..e9ab22e 100644
+index a2df586..35c5ca6 100644
 --- a/numpy/core/src/umath/ufunc_object.c
 +++ b/numpy/core/src/umath/ufunc_object.c
-@@ -27,6 +27,7 @@
+@@ -28,6 +28,7 @@
  #define NPY_NO_DEPRECATED_API NPY_API_VERSION
  
  #include "Python.h"
@@ -1055,59 +1097,81 @@ index 59fc5aa..e9ab22e 100644
  
  #include "npy_config.h"
  
-@@ -48,6 +49,7 @@
- #include "npy_import.h"
+@@ -47,6 +48,7 @@
  #include "extobj.h"
  #include "common.h"
+ #include "numpyos.h"
 +#include "mkl_cpy.h"
  
  /********** PRINTF DEBUG TRACING **************/
  #define NPY_UF_DBG_TRACING 0
 diff --git a/numpy/core/src/umath/ufunc_type_resolution.c b/numpy/core/src/umath/ufunc_type_resolution.c
-index 1766ba5..2ad0fb2 100644
+index ec60d9c..e876d33 100644
 --- a/numpy/core/src/umath/ufunc_type_resolution.c
 +++ b/numpy/core/src/umath/ufunc_type_resolution.c
-@@ -12,6 +12,7 @@
+@@ -13,6 +13,7 @@
  #define NPY_NO_DEPRECATED_API NPY_API_VERSION
  
  #include "Python.h"
 +#include "aligned_alloc.h"
  
  #include "npy_config.h"
- #define PY_ARRAY_UNIQUE_SYMBOL _npy_umathmodule_ARRAY_API
-@@ -23,6 +24,7 @@
+ #include "npy_pycompat.h"
+@@ -21,6 +22,7 @@
  #include "ufunc_type_resolution.h"
  #include "ufunc_object.h"
  #include "common.h"
 +#include "mkl_cpy.h"
  
- static const char *
- npy_casting_to_string(NPY_CASTING casting)
+ #include "mem_overlap.h"
+ #if defined(HAVE_CBLAS)
 diff --git a/numpy/core/src/umath/umathmodule.c b/numpy/core/src/umath/umathmodule.c
-index 5567b9b..2eb71cb 100644
+index 5de19fe..0f5fb38 100644
 --- a/numpy/core/src/umath/umathmodule.c
 +++ b/numpy/core/src/umath/umathmodule.c
-@@ -20,6 +20,7 @@
+@@ -21,6 +21,7 @@
  
  #include "Python.h"
  
 +#include "aligned_alloc.h"
  #include "npy_config.h"
- #define PY_ARRAY_UNIQUE_SYMBOL _npy_umathmodule_ARRAY_API
  
-@@ -285,6 +286,7 @@ static struct PyModuleDef moduledef = {
- #endif
+ #include "numpy/arrayobject.h"
+@@ -30,6 +31,7 @@
  
- #include <stdio.h>
+ #include "numpy/npy_math.h"
+ #include "number.h"
 +#include "mkl_cpy.h"
  
- #if defined(NPY_PY3K)
- #define RETVAL(x) x
+ static PyUFuncGenericFunction pyfunc_functions[] = {PyUFunc_On_Om};
+ 
+diff --git a/numpy/core/tests/test_regression.py b/numpy/core/tests/test_regression.py
+index 2421a11..d3c6124 100644
+--- a/numpy/core/tests/test_regression.py
++++ b/numpy/core/tests/test_regression.py
+@@ -1330,6 +1330,17 @@ class TestRegression(object):
+             np.arange(sz)
+             assert_(np.size == sz)
+ 
++    @dec.skipif(True, reason="Memory hog. Skip to save infrastructure resources")
++    def test_huge_array_copy(self):
++        #check behavior of altered memcpy/memmove when size of array > 2**sizeof(int)
++        try:
++            arr1 = np.ones([715827883, 3], np.double)
++            arr2 = np.copy(arr1)
++            assert_equal(arr1, arr2)
++        except MemoryError as e:
++            #if cannot allocate memory, let the test pass
++            pass
++
+     def test_fromiter_bytes(self):
+         # Ticket #1058
+         a = np.fromiter(list(range(10)), dtype='b')
 diff --git a/numpy/random/setup.py b/numpy/random/setup.py
-index a8d82b1..d38f1e0 100644
+index 394a70e..c6c92cd 100644
 --- a/numpy/random/setup.py
 +++ b/numpy/random/setup.py
-@@ -5,6 +5,7 @@ import os
+@@ -4,6 +4,7 @@ from os.path import join
  import sys
  from distutils.dep_util import newer
  from distutils.msvccompiler import get_build_version as get_msvc_build_version
@@ -1115,16 +1179,16 @@ index a8d82b1..d38f1e0 100644
  
  def needs_mingw_ftime_workaround():
      # We need the mingw workaround for _ftime if the msvc runtime version is
-@@ -43,7 +44,7 @@ def configuration(parent_package='',top_path=None):
-     # see https://github.com/cython/cython/issues/2494
-     defs.append(('CYTHON_SMALL_CODE', ''))
+@@ -39,7 +40,7 @@ def configuration(parent_package='',top_path=None):
+     if needs_mingw_ftime_workaround():
+         defs.append(("NPY_NEEDS_MINGW_TIME_WORKAROUND", None))
  
 -    libs = []
 +    libs = ['mkl_cp']
      # Configure mtrand
      config.add_extension('mtrand',
                           sources=[join('mtrand', x) for x in
-@@ -54,6 +55,7 @@ def configuration(parent_package='',top_path=None):
+@@ -50,6 +51,7 @@ def configuration(parent_package='',top_path=None):
                                    join('mtrand', '*.pyx'),
                                    join('mtrand', '*.pxi'),],
                           define_macros=defs,
@@ -1133,5 +1197,5 @@ index a8d82b1..d38f1e0 100644
  
      config.add_data_files(('.', join('mtrand', 'randomkit.h')))
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0010-intel-init_mkl.patch
+++ b/recipe/0010-intel-init_mkl.patch
@@ -1,12 +1,12 @@
-From 3a7dccb2e64ee443f382eb6bc7fa485fa32aa117 Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Thu, 26 Jul 2018 11:52:34 -0500
+From 02fe75433dd3ec86e7e3ec31b7bf51ee330371f4 Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 10:26:45 +0000
 Subject: [PATCH 10/15] intel init_mkl
 
 ---
- numpy/_distributor_init.py |  27 ++++++++
- numpy/_mklinitmodule.c     | 154 +++++++++++++++++++++++++++++++++++++++++++++
- numpy/setup.py             |  14 ++++-
+ numpy/_distributor_init.py |  27 +++++++
+ numpy/_mklinitmodule.c     | 154 +++++++++++++++++++++++++++++++++++++
+ numpy/setup.py             |  14 +++-
  3 files changed, 194 insertions(+), 1 deletion(-)
  create mode 100644 numpy/_mklinitmodule.c
 
@@ -238,5 +238,5 @@ index 4ccdaee..3d06cf6 100644
  if __name__ == '__main__':
      print('This is the wrong setup.py file to run')
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0011-intel-mkl_random.patch
+++ b/recipe/0011-intel-mkl_random.patch
@@ -1,6 +1,6 @@
-From 5f925934c02327e79fcfa0570504c81210cbbcba Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Thu, 26 Jul 2018 11:52:57 -0500
+From 15ca081b39d0107ee86636dd5496b2031f233dee Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 10:47:03 +0000
 Subject: [PATCH 11/15] intel mkl_random
 
 ---
@@ -11,7 +11,6 @@ Subject: [PATCH 11/15] intel mkl_random
  4 files changed, 20 insertions(+)
  create mode 100644 numpy/random_intel/__init__.py
  create mode 100644 numpy/random_intel/setup.py
- mode change 100644 => 100755 numpy/setup.py
 
 diff --git a/numpy/random_intel/__init__.py b/numpy/random_intel/__init__.py
 new file mode 100644
@@ -43,9 +42,7 @@ index 0000000..6d4fecf
 +    from numpy.distutils.core import setup
 +    setup(configuration=configuration)
 diff --git a/numpy/setup.py b/numpy/setup.py
-old mode 100644
-new mode 100755
-index 3d06cf6..0098b56
+index 3d06cf6..0098b56 100644
 --- a/numpy/setup.py
 +++ b/numpy/setup.py
 @@ -29,6 +29,7 @@ def configuration(parent_package='',top_path=None):
@@ -70,5 +67,5 @@ index aa6f69f..8b062ad 100644
              # default encoding is defined (e.g. LANG='C')
              with tokenize.open(str(path)) as file:
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0012-Remove-ICC-specific-flags.patch
+++ b/recipe/0012-Remove-ICC-specific-flags.patch
@@ -1,6 +1,6 @@
-From 22671eb66704c198ccb0007f20a58b796ad825e2 Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Mon, 11 Jun 2018 17:03:58 -0500
+From 46c65ff19ff2ea5bbd41aa875733734e00056313 Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 11:10:36 +0000
 Subject: [PATCH 12/15] Remove ICC specific flags
 
 ---
@@ -8,38 +8,38 @@ Subject: [PATCH 12/15] Remove ICC specific flags
  1 file changed, 8 insertions(+), 7 deletions(-)
 
 diff --git a/numpy/core/setup.py b/numpy/core/setup.py
-index 2d35844..1ec6e71 100644
+index 486319e..6e7b64a 100644
 --- a/numpy/core/setup.py
 +++ b/numpy/core/setup.py
-@@ -872,7 +872,7 @@ def configuration(parent_package='',top_path=None):
-                                   generate_numpy_api,
-                                   join(codegen_dir, 'generate_numpy_api.py'),
-                                   join('*.py')],
--                         extra_compile_args=['/Qstd=c99' if platform.system() == "Windows" else ''],
-+                         extra_compile_args=[],
-                          depends=deps + multiarray_deps,
-                          libraries=['npymath', 'npysort', 'aligned_alloc', 'mkl_cp'],
-                          extra_info=get_info('mkl'))
-@@ -928,12 +928,13 @@ def configuration(parent_package='',top_path=None):
-             join('src', 'private', 'binop_override.h')] + npymath_sources
+@@ -933,12 +933,13 @@ def configuration(parent_package='',top_path=None):
+             join(codegen_dir, 'generate_ufunc_api.py'),
+             ]
  
-     npymathc_path = join('build', 'src.%s-%s.%s' % (sysconfig.get_platform(), sys.version_info[0], sys.version_info[1]), 'numpy', 'core', 'src', 'npymath')
 -    if platform.system() == "Windows":
 -        eca = ['/fp:fast=2', '/Qimf-precision=high', '/Qprec-sqrt', '/Qstd=c99']
 -        if sys.version_info < (3, 0):
 -            eca.append('/Qprec-div')
 -    else:
--        eca = ['-fp-model fast=2', '-fimf-precision=high', '-prec-sqrt']
+-        eca = ['-fp-model', 'fast=2', '-fimf-precision=high', '-prec-sqrt']
 +#    if platform.system() == "Windows":
 +#        eca = ['/fp:fast=2', '/Qimf-precision=high', '/Qprec-sqrt', '/Qstd=c99']
 +#        if sys.version_info < (3, 0):
 +#            eca.append('/Qprec-div')
 +#    else:
-+#        eca = ['-fp-model fast=2', '-fimf-precision=high', '-prec-sqrt']
++#        eca = ['-fp-model', 'fast=2', '-fimf-precision=high', '-prec-sqrt']
 +    eca=[]
      config.add_library('loops',
                         sources=loops_src,
-                        include_dirs=[npymathc_path],
+                        include_dirs=[],
+@@ -958,7 +959,7 @@ def configuration(parent_package='',top_path=None):
+                                   generate_umath_c,
+                                   generate_ufunc_api,
+                                  ] + aligned_alloc_sources,
+-                         extra_compile_args=['/Qstd=c99' if platform.system() == "Windows" else ''],
++                         extra_compile_args=[],
+                          depends=deps + multiarray_deps + umath_deps +
+                                 common_deps,
+                          libraries=['loops', 'npymath', 'npysort', 'mkl_cp'],
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0013-Remove-np.invsqrt.patch
+++ b/recipe/0013-Remove-np.invsqrt.patch
@@ -1,25 +1,25 @@
-From 2a632daae5fb20185b6d1f567f93a8b85ff61dd1 Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Tue, 12 Jun 2018 09:11:09 -0500
+From 55aca72e65f9e1b16e196628235c55b28ffc60c9 Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 11:19:29 +0000
 Subject: [PATCH 13/15] Remove np.invsqrt
 
 ---
- numpy/core/code_generators/generate_umath.py   |  9 ---------
- numpy/core/code_generators/ufunc_docstrings.py | 28 --------------------------
- numpy/core/include/numpy/npy_math.h            |  6 ------
- numpy/core/setup_common.py                     |  2 +-
- numpy/core/src/npymath/npy_math_complex.c.src  | 13 ++----------
- numpy/core/src/npymath/npy_math_internal.h.src | 17 ++--------------
- numpy/core/src/umath/funcs.inc.src             |  7 -------
- numpy/core/src/umath/loops.c.src               | 28 --------------------------
- numpy/core/src/umath/loops.h.src               |  2 +-
+ numpy/core/code_generators/generate_umath.py  |  9 ------
+ .../core/code_generators/ufunc_docstrings.py  | 28 -------------------
+ numpy/core/include/numpy/npy_math.h           |  6 ----
+ numpy/core/setup_common.py                    |  2 +-
+ numpy/core/src/npymath/npy_math_complex.c.src | 13 ++-------
+ .../core/src/npymath/npy_math_internal.h.src  | 17 ++---------
+ numpy/core/src/umath/funcs.inc.src            |  7 -----
+ numpy/core/src/umath/loops.c.src              | 28 -------------------
+ numpy/core/src/umath/loops.h.src              |  2 +-
  9 files changed, 6 insertions(+), 106 deletions(-)
 
 diff --git a/numpy/core/code_generators/generate_umath.py b/numpy/core/code_generators/generate_umath.py
-index 94b2a13..ea52f3c 100644
+index bb37080..615f435 100644
 --- a/numpy/core/code_generators/generate_umath.py
 +++ b/numpy/core/code_generators/generate_umath.py
-@@ -782,15 +782,6 @@ defdict = {
+@@ -785,15 +785,6 @@ defdict = {
            TD(inexact, f='sqrt', astype={'e':'f'}),
            TD(P, f='sqrt'),
            ),
@@ -36,10 +36,10 @@ index 94b2a13..ea52f3c 100644
      Ufunc(1, 1, None,
            docstrings.get('numpy.core.umath.cbrt'),
 diff --git a/numpy/core/code_generators/ufunc_docstrings.py b/numpy/core/code_generators/ufunc_docstrings.py
-index 39b8827..ece0b9c 100644
+index 9cf52c0..65558f5 100644
 --- a/numpy/core/code_generators/ufunc_docstrings.py
 +++ b/numpy/core/code_generators/ufunc_docstrings.py
-@@ -3443,34 +3443,6 @@ add_newdoc('numpy.core.umath', 'sqrt',
+@@ -3567,34 +3567,6 @@ add_newdoc('numpy.core.umath', 'sqrt',
  
      """)
  
@@ -127,10 +127,10 @@ index 91ea82e..dd4876d 100644
  npy_clongdouble npy_ccosl(npy_clongdouble z);
  npy_clongdouble npy_csinl(npy_clongdouble z);
 diff --git a/numpy/core/setup_common.py b/numpy/core/setup_common.py
-index 9f93b00..7cb9680 100644
+index c242e18..edc7b8f 100644
 --- a/numpy/core/setup_common.py
 +++ b/numpy/core/setup_common.py
-@@ -107,7 +107,7 @@ MANDATORY_FUNCS = ["sin", "cos", "tan", "sinh", "cosh", "tanh", "fabs",
+@@ -108,7 +108,7 @@ MANDATORY_FUNCS = ["sin", "cos", "tan", "sinh", "cosh", "tanh", "fabs",
  # Standard functions which may not be available and for which we have a
  # replacement implementation. Note that some of these are C99 functions.
  OPTIONAL_STDFUNCS = ["expm1", "log1p", "acosh", "asinh", "atanh",
@@ -138,7 +138,7 @@ index 9f93b00..7cb9680 100644
 +        "rint", "trunc", "exp2", "log2", "hypot", "atan2", "pow",
          "copysign", "nextafter", "ftello", "fseeko",
          "strtoll", "strtoull", "cbrt", "strtold_l", "fallocate",
-         "backtrace"]
+         "backtrace", "madvise"]
 diff --git a/numpy/core/src/npymath/npy_math_complex.c.src b/numpy/core/src/npymath/npy_math_complex.c.src
 index e1de1e1..d2fae29 100644
 --- a/numpy/core/src/npymath/npy_math_complex.c.src
@@ -187,10 +187,11 @@ index 6f919f1..127d3df 100644
   *         LOG,ERF,EXP,EXPM1,ASIN,ACOS,ATAN,ASINH,ACOSH,ATANH,LOG1P,EXP2,LOG2#
   */
  
-@@ -473,19 +473,6 @@ NPY_INPLACE @type@ npy_@kind@@c@(@type@ x)
+@@ -472,19 +472,6 @@ NPY_INPLACE @type@ npy_@kind@@c@(@type@ x)
+ 
  /**end repeat1**/
  
- /**begin repeat1
+-/**begin repeat1
 - * #kind = invsqrt#
 - * #KIND = INVSQRT#
 - */
@@ -203,36 +204,39 @@ index 6f919f1..127d3df 100644
 -
 -/**end repeat1**/
 -
--/**begin repeat1
+ /**begin repeat1
   * #kind = atan2,hypot,pow,fmod,copysign#
   * #KIND = ATAN2,HYPOT,POW,FMOD,COPYSIGN#
-  */
 diff --git a/numpy/core/src/umath/funcs.inc.src b/numpy/core/src/umath/funcs.inc.src
 index 45d80ce..af2dca1 100644
 --- a/numpy/core/src/umath/funcs.inc.src
 +++ b/numpy/core/src/umath/funcs.inc.src
-@@ -271,13 +271,6 @@ nc_sqrt@c@(@ctype@ *x, @ctype@ *r)
+@@ -270,13 +270,6 @@ nc_sqrt@c@(@ctype@ *x, @ctype@ *r)
+     return;
  }
  
- static void
+-static void
 -nc_invsqrt@c@(@ctype@ *x, @ctype@ *r)
 -{
 -    *r = npy_cinvsqrt@c@(*x);
 -    return;
 -}
 -
--static void
+ static void
  nc_rint@c@(@ctype@ *x, @ctype@ *r)
  {
-     r->real = npy_rint@c@(x->real);
 diff --git a/numpy/core/src/umath/loops.c.src b/numpy/core/src/umath/loops.c.src
-index 0cc2823..7839675 100644
+index 983dbac..4342d70 100644
 --- a/numpy/core/src/umath/loops.c.src
 +++ b/numpy/core/src/umath/loops.c.src
-@@ -1743,34 +1743,6 @@ NPY_NO_EXPORT void
-  * Float types
-  *  #type = npy_float, npy_double#
-  *  #TYPE = FLOAT, DOUBLE#
+@@ -1735,34 +1735,6 @@ NPY_NO_EXPORT void
+ 
+ /**end repeat**/
+ 
+-/**begin repeat
+- * Float types
+- *  #type = npy_float, npy_double#
+- *  #TYPE = FLOAT, DOUBLE#
 - *  #c = s, d#
 - *  #scalarf = npy_invsqrtf, npy_invsqrt#
 - */
@@ -257,15 +261,11 @@ index 0cc2823..7839675 100644
 -
 -/**end repeat**/
 -
--/**begin repeat
-- * Float types
-- *  #type = npy_float, npy_double#
-- *  #TYPE = FLOAT, DOUBLE#
-  *  #A = F, #
-  *  #c = s, d#
-  *  #scalarf = npy_expf, npy_exp#
+ /**begin repeat
+  * Float types
+  *  #type = npy_float, npy_double#
 diff --git a/numpy/core/src/umath/loops.h.src b/numpy/core/src/umath/loops.h.src
-index ecc2076..fe81360 100644
+index e939c45..f848986 100644
 --- a/numpy/core/src/umath/loops.h.src
 +++ b/numpy/core/src/umath/loops.h.src
 @@ -161,7 +161,7 @@ NPY_NO_EXPORT void
@@ -278,5 +278,5 @@ index ecc2076..fe81360 100644
   */
  NPY_NO_EXPORT void
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0014-Rewrite-inlining.patch
+++ b/recipe/0014-Rewrite-inlining.patch
@@ -1,19 +1,20 @@
-From 06229174850f1131093a9dffe17ddd353aab1c08 Mon Sep 17 00:00:00 2001
-From: Michael Sarahan <msarahan@gmail.com>
-Date: Tue, 12 Jun 2018 09:12:52 -0500
+From 4359e87781bb78e729938f392b87bf1b3372dbe2 Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 12:58:13 +0000
 Subject: [PATCH 14/15] Rewrite inlining
 
 ---
- numpy/core/src/mkl_defs/aligned_alloc.c | 139 +++-----------------------------
- numpy/core/src/mkl_defs/aligned_alloc.h |  94 +++++++++++++++++++--
- numpy/core/src/umath/loops.c.src        |  31 ++++---
- 3 files changed, 121 insertions(+), 143 deletions(-)
+ numpy/core/src/mkl_defs/aligned_alloc.c    | 142 ++-------------------
+ numpy/core/src/mkl_defs/aligned_alloc.h    |  94 +++++++++++++-
+ numpy/core/src/multiarray/item_selection.c |   2 +-
+ numpy/core/src/umath/loops.c.src           |  31 +++--
+ 4 files changed, 122 insertions(+), 147 deletions(-)
 
 diff --git a/numpy/core/src/mkl_defs/aligned_alloc.c b/numpy/core/src/mkl_defs/aligned_alloc.c
-index 667432d..37eb172 100644
+index 81e9e33..37eb172 100644
 --- a/numpy/core/src/mkl_defs/aligned_alloc.c
 +++ b/numpy/core/src/mkl_defs/aligned_alloc.c
-@@ -1,19 +1,6 @@
+@@ -1,22 +1,6 @@
 -#include "mkl.h"
 -#include <stdlib.h>
 -#include <stddef.h>
@@ -29,6 +30,9 @@ index 667432d..37eb172 100644
 -#define __8BYTES_ALIGNMENT_OFFSET(ptr) (((size_t) (ptr)) & 0x7)
 -#define MKL_INT_MAX ((size_t) (~((MKL_UINT) 0) >> 1))
 -
+-#if defined(_MSC_VER)
+-#define posix_memalign(p, a, s) (((*(p)) = _aligned_malloc((s), (a))), *(p) ?0 :errno)
+-#endif
 -static int is_tbb_enabled(void) {
 +#include "aligned_alloc.h"
 +#if !defined(_MSC_VER)
@@ -36,7 +40,7 @@ index 667432d..37eb172 100644
      static int TBB_ENABLED = -1;
      if (TBB_ENABLED == -1) {
              char* mkl_threading = getenv("MKL_THREADING_LAYER");
-@@ -22,70 +9,9 @@ static int is_tbb_enabled(void) {
+@@ -25,70 +9,9 @@ static int is_tbb_enabled(void) {
      return TBB_ENABLED;
  }
  
@@ -55,7 +59,7 @@ index 667432d..37eb172 100644
 -   }
 -}
 -
--inline void *_aligned_alloc(size_t size) {
+-void * _aligned_alloc(size_t size) {
 -    /* Only available for Linux and OSX (has been explicitly disabled on Windows : see aligned_alloc.h)
 -     * With Windows, we would run into composability issues with modules like h5py which allocate
 -     * memory using libc functions in another library, like hdf5 for instance
@@ -71,7 +75,7 @@ index 667432d..37eb172 100644
 -
 -
 -#ifdef WITH_ALIGNED_CALLOC
--inline void *_aligned_calloc(size_t nelem, size_t elsize)
+-void * _aligned_calloc(size_t nelem, size_t elsize)
 -{
 -    size_t size = nelem * elsize;
 -    void *data = _aligned_alloc(size);
@@ -108,11 +112,11 @@ index 667432d..37eb172 100644
      static int TRACEMALLOC_PRESENT = -1;
      if (TRACEMALLOC_PRESENT == -1) {
          TRACEMALLOC_PRESENT = (getenv("PYTHONTRACEMALLOC")) ? 1 : 0;
-@@ -94,53 +20,12 @@ static int is_tracemalloc_enabled(void) {
+@@ -97,53 +20,12 @@ static int is_tracemalloc_enabled(void) {
  }
  #endif
  
--inline void* call_aligned_malloc(size_t size) {
+-void* call_aligned_malloc(size_t size) {
 -#if PY_VERSION_HEX >= 0x03040000
 -    if(is_tracemalloc_enabled()){
 -        return PyMem_RawMalloc(size);
@@ -122,8 +126,16 @@ index 667432d..37eb172 100644
 -        return _aligned_alloc(size);
 -    }
 -}
--
--inline void* call_aligned_realloc(void* input, size_t size) {
++// C99 inlining model
++extern void* call_aligned_malloc(size_t);
++extern void* _aligned_alloc(size_t);
++extern void* call_aligned_calloc(size_t, size_t);
++extern void* call_aligned_realloc(void*, size_t);
++extern void call_free(void*);
++#endif // !defined(_MSC_VER)
++static int _prevent_empty_translation_unit;
+ 
+-void* call_aligned_realloc(void* input, size_t size) {
 -#if PY_VERSION_HEX >= 0x03040000
 -    if(is_tracemalloc_enabled()){
 -        return PyMem_RawRealloc(input, size);
@@ -137,7 +149,7 @@ index 667432d..37eb172 100644
 -    }
 -}
 -
--inline void* call_aligned_calloc(size_t num, size_t size) {
+-void* call_aligned_calloc(size_t num, size_t size) {
 -#if PY_VERSION_HEX >= 0x03040000
 -    if(is_tracemalloc_enabled()){
 -        return PyMem_RawCalloc(num, size);
@@ -151,16 +163,8 @@ index 667432d..37eb172 100644
 -#endif
 -    }
 -}
-+// C99 inlining model
-+extern void* call_aligned_malloc(size_t);
-+extern void* _aligned_alloc(size_t);
-+extern void* call_aligned_calloc(size_t, size_t);
-+extern void* call_aligned_realloc(void*, size_t);
-+extern void call_free(void*);
-+#endif // !defined(_MSC_VER)
-+static int _prevent_empty_translation_unit;
- 
--inline void call_free(void* ptr) {
+-
+-void call_free(void* ptr) {
 -#if PY_VERSION_HEX >= 0x03040000
 -    if(is_tracemalloc_enabled()){
 -        PyMem_RawFree(ptr);
@@ -274,11 +278,24 @@ index edd0080..acfd30b 100644
  #   define PyArray_malloc call_aligned_malloc 
  #   define PyArray_free call_free
  #   define PyArray_realloc call_aligned_realloc 
+diff --git a/numpy/core/src/multiarray/item_selection.c b/numpy/core/src/multiarray/item_selection.c
+index 7c72d49..ae144f2 100644
+--- a/numpy/core/src/multiarray/item_selection.c
++++ b/numpy/core/src/multiarray/item_selection.c
+@@ -26,7 +26,7 @@
+ #include "npy_sort.h"
+ #include "npy_partition.h"
+ #include "npy_binsearch.h"
+-#include "mkl_cpy.c"
++#include "mkl_cpy.h"
+ #include "alloc.h"
+ 
+ #define memmove(src, dst, size) call_mkl_mv(src, dst, size, __FILE__, __func__, __LINE__)
 diff --git a/numpy/core/src/umath/loops.c.src b/numpy/core/src/umath/loops.c.src
-index 7839675..9fdc0b1 100644
+index 4342d70..cadd248 100644
 --- a/numpy/core/src/umath/loops.c.src
 +++ b/numpy/core/src/umath/loops.c.src
-@@ -45,6 +45,15 @@
+@@ -42,6 +42,15 @@
  #define VML_ASM_THRESHOLD 100000
  #define VML_D_THRESHOLD 8000
  
@@ -294,7 +311,7 @@ index 7839675..9fdc0b1 100644
  #define MKL_INT_MAX ((npy_intp) ((~((MKL_UINT) 0)) >> 1))
  
  #define CHUNKED_VML_CALL2(vml_func, n, type, in1, op1)   \
-@@ -165,7 +174,7 @@
+@@ -162,7 +171,7 @@
      npy_intp is1 = steps[0], os1 = steps[1];\
      npy_intp n = dimensions[0];\
      npy_intp i;\
@@ -303,7 +320,7 @@ index 7839675..9fdc0b1 100644
      for(i = 0; i < n; i++, ip1 += is1, op1 += os1)
  
  #define UNARY_LOOP_DISPATCH(cond, body)\
-@@ -2598,7 +2607,7 @@ NPY_NO_EXPORT void
+@@ -2594,7 +2603,7 @@ NPY_NO_EXPORT void
  		    if( DISJOINT_OR_SAME(op1_shifted, ip1_aligned, j_max, 1) &&
  			DISJOINT_OR_SAME(op1_shifted, ip2_shifted, j_max, 1) ) {
  			__assume_aligned(ip1_aligned, 64);
@@ -312,7 +329,7 @@ index 7839675..9fdc0b1 100644
  			for(j = 0; j < j_max; j++) {
  			    op1_shifted[j] = ip1_aligned[j] @OP@ ip2_shifted[j];
  			}
-@@ -2766,7 +2775,7 @@ NPY_NO_EXPORT void
+@@ -2762,7 +2771,7 @@ NPY_NO_EXPORT void
  		    if( DISJOINT_OR_SAME(op1_shifted, ip1_aligned, j_max, 1) &&
  			DISJOINT_OR_SAME(op1_shifted, ip2_shifted, j_max, 1) ) {
  			__assume_aligned(ip1_aligned, 64);
@@ -321,7 +338,7 @@ index 7839675..9fdc0b1 100644
  			for(j = 0; j < j_max; j++) {
  			    op1_shifted[j] = ip1_aligned[j] @OP@ ip2_shifted[j];
  			}
-@@ -2934,7 +2943,7 @@ NPY_NO_EXPORT void
+@@ -2930,7 +2939,7 @@ NPY_NO_EXPORT void
  		    if( DISJOINT_OR_SAME(op1_shifted, ip1_aligned, j_max, 1) &&
  			DISJOINT_OR_SAME(op1_shifted, ip2_shifted, j_max, 1) ) {
  			__assume_aligned(ip1_aligned, 64);
@@ -330,7 +347,7 @@ index 7839675..9fdc0b1 100644
  			for(j = 0; j < j_max; j++) {
  			    op1_shifted[j] = ip1_aligned[j] @OP@ ip2_shifted[j];
  			}
-@@ -3088,7 +3097,7 @@ NPY_NO_EXPORT void
+@@ -3084,7 +3093,7 @@ NPY_NO_EXPORT void
              const npy_intp blocked_end = npy_blocked_end(peel, sizeof(@type@), vsize, n);
              npy_intp i;
  
@@ -339,7 +356,7 @@ index 7839675..9fdc0b1 100644
              for(i = 0; i < peel; i++) {
                  op1[i] = ip1[i] @OP@ ip2[i];
              }
-@@ -3101,7 +3110,7 @@ NPY_NO_EXPORT void
+@@ -3097,7 +3106,7 @@ NPY_NO_EXPORT void
  		    if( DISJOINT_OR_SAME(op1_shifted, ip1_aligned, j_max, 1) &&
  			DISJOINT_OR_SAME(op1_shifted, ip2_shifted, j_max, 1) ) {
  			__assume_aligned(ip1_aligned, 64);
@@ -348,7 +365,7 @@ index 7839675..9fdc0b1 100644
  			for(j = 0; j < j_max; j++) {
  			    op1_shifted[j] = ip1_aligned[j] @OP@ ip2_shifted[j];
  			}
-@@ -3116,7 +3125,7 @@ NPY_NO_EXPORT void
+@@ -3112,7 +3121,7 @@ NPY_NO_EXPORT void
                  }
              }
  
@@ -357,7 +374,7 @@ index 7839675..9fdc0b1 100644
              for(; i < n; i++) {
                  op1[i] = ip1[i] @OP@ ip2[i];
              }
-@@ -3132,7 +3141,7 @@ NPY_NO_EXPORT void
+@@ -3128,7 +3137,7 @@ NPY_NO_EXPORT void
          npy_intp i;
  
          const @type@ ip1c = ip1[0];
@@ -366,7 +383,7 @@ index 7839675..9fdc0b1 100644
          for(i = 0; i < peel; i++) {
              op1[i] = ip1c @OP@ ip2[i];
          }
-@@ -3151,7 +3160,7 @@ NPY_NO_EXPORT void
+@@ -3147,7 +3156,7 @@ NPY_NO_EXPORT void
              }
          }
  
@@ -375,7 +392,7 @@ index 7839675..9fdc0b1 100644
          for(; i < n; i++) {
              op1[i] = ip1c @OP@ ip2[i];
          }
-@@ -3166,7 +3175,7 @@ NPY_NO_EXPORT void
+@@ -3162,7 +3171,7 @@ NPY_NO_EXPORT void
          npy_intp i;
  
          const @type@ ip2c = ip2[0];
@@ -384,7 +401,7 @@ index 7839675..9fdc0b1 100644
          for(i = 0; i < peel; i++) {
              op1[i] = ip1[i] @OP@ ip2c;
          }
-@@ -3185,7 +3194,7 @@ NPY_NO_EXPORT void
+@@ -3181,7 +3190,7 @@ NPY_NO_EXPORT void
              }
          }
  
@@ -394,5 +411,5 @@ index 7839675..9fdc0b1 100644
              op1[i] = ip1[i] @OP@ ip2c;
          }
 -- 
-2.7.4
+2.20.1
 

--- a/recipe/0015-Fixes-from-Intel-Distribution.patch
+++ b/recipe/0015-Fixes-from-Intel-Distribution.patch
@@ -1,0 +1,25 @@
+From 47a8e80cc22a9e9beb9d0fb942fa848c3d817ebe Mon Sep 17 00:00:00 2001
+From: Stuart Archibald <redacted>
+Date: Fri, 22 Feb 2019 14:41:38 +0000
+Subject: [PATCH 15/15] Fixes from Intel Distribution
+
+---
+ numpy/core/tests/test_regression.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/numpy/core/tests/test_regression.py b/numpy/core/tests/test_regression.py
+index d3c6124..a023c82 100644
+--- a/numpy/core/tests/test_regression.py
++++ b/numpy/core/tests/test_regression.py
+@@ -1330,7 +1330,7 @@ class TestRegression(object):
+             np.arange(sz)
+             assert_(np.size == sz)
+ 
+-    @dec.skipif(True, reason="Memory hog. Skip to save infrastructure resources")
++    @pytest.mark.skipif(True, reason="Memory hog. Skip to save infrastructure resources")
+     def test_huge_array_copy(self):
+         #check behavior of altered memcpy/memmove when size of array > 2**sizeof(int)
+         try:
+-- 
+2.20.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "numpy" %}
-{% set version = "1.15.4" %}
+{% set version = "1.16.0" %}
 {% set mkl_random_version = "1.0.2" %}
 {% set mkl_random_buildnumber = 0 %}
 {% set mkl_fft_version = "1.0.6" %}
@@ -11,7 +11,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
-    sha256: 3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7
+    sha256: cb189bd98b2e7ac02df389b6212846ab20661f4bafe16b5a70a6f1728c1cc7cb
     patches:
       - 0001-fix-windows-case-sensitivity.patch
       - 0002-simplify-arch-flags.patch
@@ -30,10 +30,8 @@ source:
       - 0012-Remove-ICC-specific-flags.patch
       - 0013-Remove-np.invsqrt.patch
       - 0014-Rewrite-inlining.patch
+      - 0015-Fixes-from-Intel-Distribution.patch
       {%- endif %}
-      # precision issue with longdouble on ppc64le
-      # https://github.com/numpy/numpy/pull/8566
-      - 0015-skip-test_loss_of_precision_longcomplex-test.patch  # [ppc64le]
   {% if blas_impl == "mkl" %}
   # because of the cyclical nature of numpy and mkl_fft/mkl_random, they all need to be built in this one recipe
   - url: https://github.com/IntelPython/mkl_random/archive/v{{mkl_random_version}}.tar.gz


### PR DESCRIPTION
This updates the build to accommodate NumPy 1.16 and corresponding
performance patches from Intel.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
