### PR TITLE
Rebuild numpy 1.21.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,10 @@ source:
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
 
 build:
-  number: 1
+  number: 2
   # numpy 1.20.0 no longer supports Python 3.6: https://numpy.org/doc/stable/release/1.20.0-notes.html
   # "The Python versions supported for this release are 3.7-3.9, support for Python 3.6 has been dropped"
-  skip: True  # [(blas_impl == 'openblas' and win) or py2k or py<37]
+  skip: True  # [(blas_impl == 'openblas' and win) or py<37 or py>311]
   force_use_keys:
     - python
 
@@ -46,8 +46,10 @@ outputs:
       host:
         - python
         - pip
-        - cython >=0.29.21
+        - packaging  # [osx and arm64]
+        - cython >=0.29.24
         - setuptools <60.0.0
+        - wheel 0.37.0
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
       run:
@@ -76,7 +78,10 @@ outputs:
         - armpl  # [aarch64]
       host:
         - python
+        - packaging  # [osx and arm64]
+        - cython >=0.29.24
         - setuptools <60.0.0
+        - wheel 0.37.0
         # these import blas metapackages to ensure consistency with downstream libs that also use blas
         - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
         - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']
@@ -133,7 +138,16 @@ outputs:
         - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0
       imports:
         - numpy
+        - numpy.core.multiarray
+        - numpy.core._multiarray_tests
+        - numpy.core.numeric
+        - numpy.core._operand_flag_tests
+        - numpy.core._struct_ufunc_tests
+        - numpy.core._rational_tests
+        - numpy.core.umath
+        - numpy.core._umath_tests
         - numpy.linalg.lapack_lite
+        - numpy.random.mtrand
 
 about:
   home: https://numpy.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ build:
   number: 2
   # numpy 1.20.0 no longer supports Python 3.6: https://numpy.org/doc/stable/release/1.20.0-notes.html
   # "The Python versions supported for this release are 3.7-3.9, support for Python 3.6 has been dropped"
+  # numpy 1.21.x set Python upper bound <3.11, see https://github.com/numpy/numpy/commit/1e8d6a83985f3191c63963414981743adc4353cf
   skip: True  # [(blas_impl == 'openblas' and win) or py<37 or py>311]
   force_use_keys:
     - python
@@ -35,7 +36,7 @@ outputs:
     script: install_base.bat  # [win]
     build:
       entry_points:
-        - f2py = numpy.f2py.f2py2e:main  # [win]
+        - f2py = numpy.f2py.f2py2e:main
       missing_dso_whitelist:  # [s390x]
         - $RPATH/ld64.so.1    # [s390x]
     requirements:
@@ -49,7 +50,7 @@ outputs:
         - packaging  # [osx and arm64]
         - cython >=0.29.24
         - setuptools <60.0.0
-        - wheel 0.37.0
+        - wheel >=0.37.0
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
       run:
@@ -81,7 +82,7 @@ outputs:
         - packaging  # [osx and arm64]
         - cython >=0.29.24
         - setuptools <60.0.0
-        - wheel 0.37.0
+        - wheel >=0.37.0
         # these import blas metapackages to ensure consistency with downstream libs that also use blas
         - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
         - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -140,13 +140,8 @@ outputs:
       imports:
         - numpy
         - numpy.core.multiarray
-        - numpy.core._multiarray_tests
         - numpy.core.numeric
-        - numpy.core._operand_flag_tests
-        - numpy.core._struct_ufunc_tests
-        - numpy.core._rational_tests
         - numpy.core.umath
-        - numpy.core._umath_tests
         - numpy.linalg.lapack_lite
         - numpy.random.mtrand
 


### PR DESCRIPTION
Requirements:
- https://github.com/numpy/numpy/blob/v1.21.5/pyproject.toml
- https://github.com/numpy/numpy/blob/v1.21.5/tools/cythonize.py
- https://github.com/numpy/numpy/blob/v1.21.5/environment.yml
- https://github.com/numpy/numpy/blob/v1.21.5/setup.py
- https://github.com/numpy/numpy/blob/v1.21.5/test_requirements.txt

Actions:
1. Bump build number to `2`
2. Remove skipping `py2k`
3. Skip `py>311`, see https://github.com/numpy/numpy/blob/c3d0a09342c08c466984654bc4738af595fba896/setup.py#L409
4. Update host requirements: 
- add `packaging` for `osx-arm64,` see https://github.com/numpy/numpy/blob/c3d0a09342c08c466984654bc4738af595fba896/pyproject.toml#L4
- update pinning to `cython >=0.29.24`, see https://github.com/numpy/numpy/blob/c3d0a09342c08c466984654bc4738af595fba896/pyproject.toml#L6 and https://github.com/numpy/numpy/blob/c3d0a09342c08c466984654bc4738af595fba896/tools/cythonize.py#L76
- add `wheel 0.37.0,` see https://github.com/numpy/numpy/blob/c3d0a09342c08c466984654bc4738af595fba896/pyproject.toml#L6
6. Add more `test/imports`