### PR TITLE
Rebuild numpy 1.21

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,3 +9,5 @@ cxx_compiler_version:      # [ppc64le]
   - 8.2.0                  # [ppc64le]
 fortran_compiler_version:  # [ppc64le]
   - 8.2.0                  # [ppc64le]
+openblas:
+  - 0.3.20

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,11 +3,11 @@
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: no
-c_compiler_version:        # [ppc64le]
-  - 8.2.0                  # [ppc64le]
-cxx_compiler_version:      # [ppc64le]
-  - 8.2.0                  # [ppc64le]
-fortran_compiler_version:  # [ppc64le]
-  - 8.2.0                  # [ppc64le]
+c_compiler_version:        # [linux]
+  - 11.2.0                 # [linux]
+cxx_compiler_version:      # [linux]
+  - 11.2.0                 # [linux]
+fortran_compiler_version:  # [linux or osx]
+  - 11.2.0                 # [linux or osx]
 openblas:
   - 0.3.20

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
 
 build:
-  number: 2
+  number: 3
   # numpy 1.20.0 no longer supports Python 3.6: https://numpy.org/doc/stable/release/1.20.0-notes.html
   # "The Python versions supported for this release are 3.7-3.9, support for Python 3.6 has been dropped"
   # numpy 1.21.x set Python upper bound <3.11, see https://github.com/numpy/numpy/commit/1e8d6a83985f3191c63963414981743adc4353cf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -120,6 +120,14 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_full_reimport" %}          # [ppc64le or s390x]
     {% set tests_to_skip = tests_to_skip + " or test_pep338" %}                 # [ppc64le or s390x]
     {% set tests_to_skip = tests_to_skip + " or test_no_typing_extensions" %}   # [ppc64le or s390x]
+    # Specific to M1, possibly related:
+    # https://github.com/numpy/numpy/issues/21322
+    # https://github.com/numpy/numpy/issues/20023
+    {% set tests_to_skip = tests_to_skip + " or test_generalized_herm_cases" %}  # [osx and arm64]
+    {% set tests_to_skip = tests_to_skip + " or test_herm_cases" %}              # [osx and arm64]
+    # Seems to be a long-standing issue:
+    # https://github.com/numpy/numpy/issues/16046
+    {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}  # [s390x]
 
     test:
       requires:


### PR DESCRIPTION
Rebuild numpy 1.21 after libgfortran update and openblas rebuild.