### PR TITLE
Numpy 1.19 b1

### DIFF
--- a/recipe/0005-test-ctypeslib-py37.patch
+++ b/recipe/0005-test-ctypeslib-py37.patch
@@ -1,0 +1,15 @@
+diff -urN a/numpy/tests/test_ctypeslib.py b/numpy/tests/test_ctypeslib.py
+--- a/numpy/tests/test_ctypeslib.py	2020-09-03 22:22:06.428542900 +0300
++++ b/numpy/tests/test_ctypeslib.py	2022-06-08 15:37:00.730477760 +0300
+@@ -24,9 +24,9 @@
+         except OSError:
+             pass
+     if cdll is None:
+-        cdll = load_library('_multiarray_umath', np.core._multiarray_umath.__file__)
++        cdll = load_library('_multiarray_umath.cp37-win_amd64.pyd', np.core._multiarray_umath.__file__)
+     if test_cdll is None:
+-        test_cdll = load_library('_multiarray_tests', np.core._multiarray_tests.__file__)
++        test_cdll = load_library('_multiarray_testsi.cp37-win_amd64.pyd', np.core._multiarray_tests.__file__)
+ 
+     c_forward_pointer = test_cdll.forward_pointer
+ 

--- a/recipe/0005-test-ctypeslib-py37.patch
+++ b/recipe/0005-test-ctypeslib-py37.patch
@@ -1,6 +1,6 @@
 diff -urN a/numpy/tests/test_ctypeslib.py b/numpy/tests/test_ctypeslib.py
 --- a/numpy/tests/test_ctypeslib.py	2020-09-03 22:22:06.428542900 +0300
-+++ b/numpy/tests/test_ctypeslib.py	2022-06-08 15:53:06.651453844 +0300
++++ b/numpy/tests/test_ctypeslib.py	2022-06-08 18:09:10.184811636 +0300
 @@ -1,3 +1,4 @@
 +import os
  import sys
@@ -18,3 +18,11 @@ diff -urN a/numpy/tests/test_ctypeslib.py b/numpy/tests/test_ctypeslib.py
  
      c_forward_pointer = test_cdll.forward_pointer
  
+@@ -35,6 +36,7 @@
+                     reason="ctypes not available in this python")
+ @pytest.mark.skipif(sys.platform == 'cygwin',
+                     reason="Known to fail on cygwin")
++@pytest.mark.skip(reason="This doesn't work properly under Python 3.7")
+ class TestLoadLibrary:
+     def test_basic(self):
+         try:

--- a/recipe/0005-test-ctypeslib-py37.patch
+++ b/recipe/0005-test-ctypeslib-py37.patch
@@ -1,15 +1,20 @@
 diff -urN a/numpy/tests/test_ctypeslib.py b/numpy/tests/test_ctypeslib.py
 --- a/numpy/tests/test_ctypeslib.py	2020-09-03 22:22:06.428542900 +0300
-+++ b/numpy/tests/test_ctypeslib.py	2022-06-08 15:37:00.730477760 +0300
-@@ -24,9 +24,9 @@
++++ b/numpy/tests/test_ctypeslib.py	2022-06-08 15:53:06.651453844 +0300
+@@ -1,3 +1,4 @@
++import os
+ import sys
+ import pytest
+ import weakref
+@@ -24,9 +25,9 @@
          except OSError:
              pass
      if cdll is None:
 -        cdll = load_library('_multiarray_umath', np.core._multiarray_umath.__file__)
-+        cdll = load_library('_multiarray_umath.cp37-win_amd64.pyd', np.core._multiarray_umath.__file__)
++        cdll = load_library(os.path.basename(np.core._multiarray_umath.__file__), np.core._multiarray_umath.__file__)
      if test_cdll is None:
 -        test_cdll = load_library('_multiarray_tests', np.core._multiarray_tests.__file__)
-+        test_cdll = load_library('_multiarray_testsi.cp37-win_amd64.pyd', np.core._multiarray_tests.__file__)
++        test_cdll = load_library(os.path.basename(np.core._multiarray_tests.__file__), np.core._multiarray_tests.__file__)
  
      c_forward_pointer = test_cdll.forward_pointer
  

--- a/recipe/aarch_site.cfg
+++ b/recipe/aarch_site.cfg
@@ -1,0 +1,6 @@
+[openblas]
+libraries = armpl_lp64
+library_dirs = $PREFIX/lib
+include_dirs = $PREFIX/include
+runtime_library_dirs = $PREFIX/lib
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,13 @@
+# When building out the initial package set for a new Python version / MKL version the
+# recommendation is to build numpy-base but not numpy, then build
+# mkl_fft and mkl_random, and then numpy.
+# If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
+only_build_numpy_base: no
+c_compiler_version:        # [linux]
+  - 11.2.0                 # [linux]
+cxx_compiler_version:      # [linux]
+  - 11.2.0                 # [linux]
+fortran_compiler_version:  # [linux or osx]
+  - 11.2.0                 # [linux or osx]
+openblas:
+  - 0.3.20

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -3,7 +3,10 @@
 set -e
 
 # site.cfg is provided by blas devel packages (either mkl-devel or openblas-devel)
-cp "${PREFIX}/site.cfg" site.cfg
+case $( uname -m ) in
+aarch64) cp $RECIPE_DIR/aarch_site.cfg site.cfg;;
+*)       cp $PREFIX/site.cfg site.cfg;;
+esac
 
 # For reasons unknown, numpy insists on using the system "gcc" for linking and
 # while doing so sets the sysroot to '/', which we undo below.

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -3,6 +3,30 @@
 set -e
 
 # site.cfg is provided by blas devel packages (either mkl-devel or openblas-devel)
-cp $PREFIX/site.cfg site.cfg
+cp "${PREFIX}/site.cfg" site.cfg
+
+# For reasons unknown, numpy insists on using the system "gcc" for linking and
+# while doing so sets the sysroot to '/', which we undo below.
+if [ $(uname -s) = Linux ]; then
+    # Wrap the conda compiler in a script called "gcc".
+    cat << EOF > "${BUILD_PREFIX}/bin/gcc"
+#!/bin/bash
+
+for arg do
+    shift
+
+    # Remove -Wl,--sysroot=/ from the argument list
+    if [ "\$arg" = "-Wl,--sysroot=/" ]; then
+        continue
+    else
+        set -- "\$@" "\$arg"
+    fi
+done
+
+# Invoke the conda compiler with the modified argument list.
+exec "${BUILD_PREFIX}/bin/${BUILD}-gcc" "\$@"
+EOF
+    chmod +x "${BUILD_PREFIX}/bin/gcc"
+fi
 
 ${PYTHON} -m pip install --no-deps --ignore-installed -v .

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -4,8 +4,15 @@ set -e
 
 # site.cfg is provided by blas devel packages (either mkl-devel or openblas-devel)
 case $( uname -m ) in
-aarch64) cp $RECIPE_DIR/aarch_site.cfg site.cfg;;
-*)       cp $PREFIX/site.cfg site.cfg;;
+    aarch64)
+        cp $RECIPE_DIR/aarch_site.cfg site.cfg
+        ;;
+    s390x)
+        export CFLAGS="$CFLAGS -march=z196"
+        ;;
+    *)
+        cp $PREFIX/site.cfg site.cfg
+        ;;
 esac
 
 # For reasons unknown, numpy insists on using the system "gcc" for linking and

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -7,11 +7,16 @@ case $( uname -m ) in
     aarch64)
         cp $RECIPE_DIR/aarch_site.cfg site.cfg
         ;;
-    s390x)
-        export CFLAGS="$CFLAGS -march=z196"
-        ;;
     *)
         cp $PREFIX/site.cfg site.cfg
+        ;;
+esac
+
+# gcc default arch for s390x is z900 where we run into an internal compiler
+# error, using the slightly more modern z196 this doesn't happen.
+case $( uname -m ) in
+    s390x)
+        export CFLAGS="$CFLAGS -march=z196"
         ;;
 esac
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0004-disable-autorun-for-cmd-test.patch   # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [(blas_impl == 'openblas' and win) or py2k]
   force_use_keys:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,7 @@ outputs:
     requirements:
       build:
         - {{ compiler("c") }}
-        # libllvm10 10.0.0 build 1 has an issue building numpy, use build 0
-        - libllvm10 10.0.0 h21ff451_0  # [osx]
+        - {{ compiler("fortran") }}
       host:
         - python
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
     - 0002-intel_mkl-version.patch  # [blas_impl == "mkl"]
     - 0003-intel_init_mkl.patch  # [blas_impl == "mkl"]
     - 0004-disable-autorun-for-cmd-test.patch   # [win]
-    - 0005-test-ctypeslib-py37.patch  # [win and py<38]
 
 build:
   number: 1
@@ -106,6 +105,10 @@ outputs:
     # Reported here but never resolved?
     # https://github.com/numpy/numpy/issues/16046
     {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}
+    # Doesn't work correctly for .pyd files on Python <38, this is not a
+    # regression, previous builds exhibit the same behavior.
+    {% set tests_to_skip = tests_to_skip + " or TestLoadLibrary::test_basic" %}  # [win and py<38]
+    {% set tests_to_skip = tests_to_skip + " or TestLoadLibrary::test_basic2" %}  # [win and py<38]
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,6 +95,10 @@ outputs:
     # https://github.com/numpy/numpy/issues/20023
     {% set tests_to_skip = tests_to_skip + " or test_generalized_herm_cases" %}  # [osx and arm64]
     {% set tests_to_skip = tests_to_skip + " or test_herm_cases" %}              # [osx and arm64]
+    # Upstream decided to skip these:
+    # https://github.com/numpy/numpy/issues/17635
+    {% set tests_to_skip = tests_to_skip + " or test_inplace_floor_division_scalar_type" %}  # [osx and arm64]
+    {% set tests_to_skip = tests_to_skip + " or test_inplace_floor_division_array_type" %}   # [osx and arm64]
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,6 +90,11 @@ outputs:
     # Only the complex256 system is failing, but I don't know how to skip it on its own
     # https://github.com/numpy/numpy/issues/15243
     {% set tests_to_skip = tests_to_skip + " or test_loss_of_precision" %}  # [ppc64le or aarch64 or s390x]
+    # Specific to M1, possibly related:
+    # https://github.com/numpy/numpy/issues/21322
+    # https://github.com/numpy/numpy/issues/20023
+    {% set tests_to_skip = tests_to_skip + " or test_generalized_herm_cases" %}  # [osx and arm64]
+    {% set tests_to_skip = tests_to_skip + " or test_herm_cases" %}              # [osx and arm64]
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,8 +127,9 @@ outputs:
         - numpy.linalg.lapack_lite
 
 about:
-  home: http://numpy.scipy.org/
-  license: BSD 3-Clause
+  home: https://numpy.org/
+  license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
   summary: Array processing for numbers, strings, records, and objects.
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
     - 0002-intel_mkl-version.patch  # [blas_impl == "mkl"]
     - 0003-intel_init_mkl.patch  # [blas_impl == "mkl"]
     - 0004-disable-autorun-for-cmd-test.patch   # [win]
+    - 0005-test-ctypeslib-py37.patch  # [win]
 
 build:
   number: 1
@@ -102,9 +103,9 @@ outputs:
     # https://github.com/numpy/numpy/issues/17635
     {% set tests_to_skip = tests_to_skip + " or test_inplace_floor_division_scalar_type" %}  # [osx and arm64]
     {% set tests_to_skip = tests_to_skip + " or test_inplace_floor_division_array_type" %}   # [osx and arm64]
-    # numpy's get_shared_lib_extension returns the plain .pyd extension without
-    # platform/version identifier under Python <3.8.
-    {% set tests_to_skip = tests_to_skip + " or test_ctypeslib" %}  # [win and py<38]
+    # Reported here but never resolved?
+    # https://github.com/numpy/numpy/issues/16046
+    {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
     - 0002-intel_mkl-version.patch  # [blas_impl == "mkl"]
     - 0003-intel_init_mkl.patch  # [blas_impl == "mkl"]
     - 0004-disable-autorun-for-cmd-test.patch   # [win]
-    # See also TestLoadLibrary in the tests section below.
+    # Loading .pyd files with a version/platform identifier doesn't work correctly
+    # with Python <38, this is not a regression, previous builds exhibit the same behavior.
     - 0005-test-ctypeslib-py37.patch  # [win and py<38]
 
 build:
@@ -107,10 +108,6 @@ outputs:
     # Reported here but never resolved?
     # https://github.com/numpy/numpy/issues/16046
     {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}
-    # Doesn't work correctly for .pyd files on Python <38, this is not a
-    # regression, previous builds exhibit the same behavior.
-    {% set tests_to_skip = tests_to_skip + " or TestLoadLibrary::test_basic" %}  # [win and py<38]
-    {% set tests_to_skip = tests_to_skip + " or TestLoadLibrary::test_basic2" %}  # [win and py<38]
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ outputs:
         - f2py = numpy.f2py.f2py2e:main  # [win]
       ignore_run_exports:
         - libgfortran5  # [osx]
+      missing_dso_whitelist:
+        - '$RPATH/ld64.so.1'  # [s390x]
     requirements:
       build:
         - {{ compiler("c") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,11 @@ build:
   force_use_keys:
     - python
 
+requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
+
 outputs:
   # this one has all the actual contents
   - name: numpy-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
     - 0002-intel_mkl-version.patch  # [blas_impl == "mkl"]
     - 0003-intel_init_mkl.patch  # [blas_impl == "mkl"]
     - 0004-disable-autorun-for-cmd-test.patch   # [win]
+    # See also TestLoadLibrary in the tests section below.
+    - 0005-test-ctypeslib-py37.patch  # [win and py<38]
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,7 +89,7 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_sincos_float32" %}  # [linux64]
     # Unresolved issue around OpenBLAS:
     # https://github.com/numpy/numpy/pull/18943
-    {% set tests_to_skip = tests_to_skip + " or test_nan" %}  # [linux or osx]
+    {% set tests_to_skip = tests_to_skip + " or test_nan" %}  # [blas_impl == 'openblas' and (linux or osx)]
     # Flawed test when using MKL
     # https://github.com/numpy/numpy/issues/16769
     {% set tests_to_skip = tests_to_skip + " or test_overrides" %}  # [blas_impl == 'mkl']
@@ -107,7 +107,7 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_inplace_floor_division_array_type" %}   # [osx and arm64]
     # Reported here but never resolved?
     # https://github.com/numpy/numpy/issues/16046
-    {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}
+    {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}  # [s390x]
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ outputs:
     build:
       entry_points:
         - f2py = numpy.f2py.f2py2e:main  # [win]
+      ignore_run_exports:
+        - libgfortran5  # [osx]
     requirements:
       build:
         - {{ compiler("c") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,6 +100,9 @@ outputs:
     # https://github.com/numpy/numpy/issues/17635
     {% set tests_to_skip = tests_to_skip + " or test_inplace_floor_division_scalar_type" %}  # [osx and arm64]
     {% set tests_to_skip = tests_to_skip + " or test_inplace_floor_division_array_type" %}   # [osx and arm64]
+    # numpy's get_shared_lib_extension returns the plain .pyd extension without
+    # platform/version identifier under Python <3.8.
+    {% set tests_to_skip = tests_to_skip + " or test_ctypeslib" %}  # [win and py<38]
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,7 +81,7 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_sincos_float32" %}  # [linux64]
     # Unresolved issue around OpenBLAS:
     # https://github.com/numpy/numpy/pull/18943
-    {% set tests_to_skip = tests_to_skip + " or test_nan" %}  # [linux64]
+    {% set tests_to_skip = tests_to_skip + " or test_nan" %}  # [linux]
     # Flawed test when using MKL
     # https://github.com/numpy/numpy/issues/16769
     {% set tests_to_skip = tests_to_skip + " or test_overrides" %}  # [blas_impl == 'mkl']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ outputs:
       host:
         - python
         - pip
+        - setuptools <=51  # [win]
         - cython
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ outputs:
       host:
         - python
         - pip
+        - setuptools  # [not win]
         - setuptools <=51  # [win]
         - cython
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,7 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_sincos_float32" %}  # [linux64]
     # Unresolved issue around OpenBLAS:
     # https://github.com/numpy/numpy/pull/18943
-    {% set tests_to_skip = tests_to_skip + " or test_nan" %}  # [linux]
+    {% set tests_to_skip = tests_to_skip + " or test_nan" %}  # [linux or osx]
     # Flawed test when using MKL
     # https://github.com/numpy/numpy/issues/16769
     {% set tests_to_skip = tests_to_skip + " or test_overrides" %}  # [blas_impl == 'mkl']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0002-intel_mkl-version.patch  # [blas_impl == "mkl"]
     - 0003-intel_init_mkl.patch  # [blas_impl == "mkl"]
     - 0004-disable-autorun-for-cmd-test.patch   # [win]
-    - 0005-test-ctypeslib-py37.patch  # [win]
+    - 0005-test-ctypeslib-py37.patch  # [win and py<38]
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 1
-  skip: True  # [(blas_impl == 'openblas' and win) or py2k]
+  skip: True  # [(blas_impl == 'openblas' and win) or py<36 or py>39]
   force_use_keys:
     - python
 
@@ -79,6 +79,9 @@ outputs:
     # Seems to fail with current version of blas for large numbers
     # https://github.com/conda-forge/numpy-feedstock/pull/179#issuecomment-569591828
     {% set tests_to_skip = tests_to_skip + " or test_sincos_float32" %}  # [linux64]
+    # Unresolved issue around OpenBLAS:
+    # https://github.com/numpy/numpy/pull/18943
+    {% set tests_to_skip = tests_to_skip + " or test_nan" %}  # [linux64]
     # Flawed test when using MKL
     # https://github.com/numpy/numpy/issues/16769
     {% set tests_to_skip = tests_to_skip + " or test_overrides" %}  # [blas_impl == 'mkl']


### PR DESCRIPTION
Rebuild numpy 1.19 after libgfortran update and openblas rebuild (against new libgfortran).

A number of changes were necessary:

* Worked around the build system trying to use the system gcc for linking.
* Worked around the build system setting the system root to '/' while linking.
* Marked additional tests to be skipped with comments.
* Override site.cfg on aarch64 (taken from numpy-feedstock master).
* Constrain setuptools version on Windows to fix an incompatibility.

Plus the usual little overrides.