### PR TITLE
update `numpy` to version `1.23.3`

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,5 +4,3 @@
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: no
 
-mkl:
-  - 2021.*

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,3 +3,6 @@
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: no
+
+mkl:
+  - 2021.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ outputs:
         - python
         - pip
         - packaging  # [osx and arm64]
-        - cython >=0.29.30
+        - cython >=0.29.30,<3.0
         - setuptools <60.0.0
         - wheel >=0.37.0
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
@@ -135,6 +135,7 @@ outputs:
         - pytest-cov
         - pytest-xdist
         - hypothesis >=6.29.3
+        - pytz >=2021.3
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,7 +92,6 @@ outputs:
         # openblas or mkl runtime included with run_exports
         - mkl_fft  # [blas_impl == 'mkl']
         - mkl_random # [blas_impl == 'mkl' and (not win or vc>=14)]
-        # - mkl_umath  # [blas_impl == 'mkl']
     {% endif %}
     {% set tests_to_skip = "_not_a_real_test" %}
     # Arrays are not equal?:
@@ -133,8 +132,8 @@ outputs:
         - pip     # force installation or `test_api_importable` will fail
         - setuptools <60.0.0
         - pytest
-        - pytest-cov   # added for testing
-        - pytest-xdist # added for testing
+        - pytest-cov
+        - pytest-xdist
         - hypothesis >=6.29.3
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
@@ -149,38 +148,6 @@ outputs:
         - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0
       imports:
         - numpy
-        - numpy.array_api                 # added for testing
-        - numpy.array_api.linalg          # added for testing
-        - numpy.ctypeslib                 # added for testing
-        - numpy.distutils                 # added for testing
-        - numpy.doc                       # added for testing
-        - numpy.doc.constants             # added for testing
-        - numpy.doc.ufuncs                # added for testing
-        - numpy.f2py                      # added for testing
-        - numpy.fft                       # added for testing
-        - numpy.lib                       # added for testing
-        - numpy.lib.mixins                # added for testing
-        - numpy.lib.recfunctions          # added for testing
-        - numpy.lib.scimath               # added for testing
-        - numpy.linalg                    # added for testing
-        - numpy.ma                        # added for testing
-        - numpy.ma.extras                 # added for testing
-        - numpy.ma.mrecords               # added for testing
-        - numpy.matlib                    # added for testing
-        - numpy.polynomial                # added for testing
-        - numpy.random                    # added for testing
-        - numpy.testing                   # added for testing
-        - numpy.typing                    # added for testing
-        - numpy.version                   # added for testing
-        - numpy.core._multiarray_tests    # added for testing
-        - numpy.core.numeric              # added for testing
-        - numpy.core._operand_flag_tests  # added for testing
-        - numpy.core._struct_ufunc_tests  # added for testing
-        - numpy.core._rational_tests      # added for testing
-        - numpy.core.umath                # added for testing
-        - numpy.core._umath_tests         # added for testing
-        - numpy.linalg.lapack_lite        # added for testing
-        - numpy.random.mtrand             # added for testing
         - numpy.core.multiarray
         - numpy.core.numeric
         - numpy.core.umath

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -165,7 +165,7 @@ about:
     NumPy is the fundamental package needed for scientific computing with Python.
   doc_url: https://numpy.org/doc/stable/reference/
   dev_url: https://github.com/numpy/numpy
-  doc_source_url: https://github.com/numpy/numpy/tree/main/doc
+  doc_source_url: https://github.com/numpy/numpy/tree/main/doc 
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -165,7 +165,7 @@ about:
     NumPy is the fundamental package needed for scientific computing with Python.
   doc_url: https://numpy.org/doc/stable/reference/
   dev_url: https://github.com/numpy/numpy
-  doc_source_url: https://github.com/numpy/numpy/tree/main/doc 
+  doc_source_url: https://github.com/numpy/numpy/tree/main/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -163,7 +163,7 @@ about:
   description: |
     NumPy is the fundamental package needed for scientific computing with Python.
   doc_url: https://numpy.org/doc/stable/reference/
-  dev_url: https://github.com/numpy/numpy
+  dev_url: https://github.com/numpy/numpy 
   doc_source_url: https://github.com/numpy/numpy/tree/main/doc
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -163,7 +163,7 @@ about:
   description: |
     NumPy is the fundamental package needed for scientific computing with Python.
   doc_url: https://numpy.org/doc/stable/reference/
-  dev_url: https://github.com/numpy/numpy 
+  dev_url: https://github.com/numpy/numpy
   doc_source_url: https://github.com/numpy/numpy/tree/main/doc
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -157,7 +157,7 @@ outputs:
 about:
   home: https://numpy.org/
   license: BSD-3-Clause
-  lisense_family: BSD
+  license_family: BSD
   license_file: LICENSE.txt
   summary: Array processing for numbers, strings, records, and objects.
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -162,9 +162,9 @@ about:
   summary: Array processing for numbers, strings, records, and objects.
   description: |
     NumPy is the fundamental package needed for scientific computing with Python.
-  doc_url: https://docs.scipy.org/doc/numpy/reference/
+  doc_url: https://numpy.org/doc/stable/reference/
   dev_url: https://github.com/numpy/numpy
-  doc_source_url: https://github.com/numpy/numpy/tree/master/doc
+  doc_source_url: https://github.com/numpy/numpy/tree/main/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.23.1" %}
+{% set version = "1.23.3" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: d748ef349bfef2e1194b59da37ed5a29c19ea8d7e6342019921ba2ba4fd8b624
+  sha256: 51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]
@@ -133,11 +133,14 @@ outputs:
         - pip     # force installation or `test_api_importable` will fail
         - setuptools <60.0.0
         - pytest
-        - hypothesis
+        - pytest-cov   # added for testing
+        - pytest-xdist # added for testing
+        - hypothesis >=6.29.3
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]
         - nomkl  # [x86 and blas_impl != 'mkl']
+        - typing-extensions >=4.2.0
       commands:
         - f2py -h
         - python -c "import numpy; numpy.show_config()"
@@ -146,6 +149,38 @@ outputs:
         - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0
       imports:
         - numpy
+        - numpy.array_api                 # added for testing
+        - numpy.array_api.linalg          # added for testing
+        - numpy.ctypeslib                 # added for testing
+        - numpy.distutils                 # added for testing
+        - numpy.doc                       # added for testing
+        - numpy.doc.constants             # added for testing
+        - numpy.doc.ufuncs                # added for testing
+        - numpy.f2py                      # added for testing
+        - numpy.fft                       # added for testing
+        - numpy.lib                       # added for testing
+        - numpy.lib.mixins                # added for testing
+        - numpy.lib.recfunctions          # added for testing
+        - numpy.lib.scimath               # added for testing
+        - numpy.linalg                    # added for testing
+        - numpy.ma                        # added for testing
+        - numpy.ma.extras                 # added for testing
+        - numpy.ma.mrecords               # added for testing
+        - numpy.matlib                    # added for testing
+        - numpy.polynomial                # added for testing
+        - numpy.random                    # added for testing
+        - numpy.testing                   # added for testing
+        - numpy.typing                    # added for testing
+        - numpy.version                   # added for testing
+        - numpy.core._multiarray_tests    # added for testing
+        - numpy.core.numeric              # added for testing
+        - numpy.core._operand_flag_tests  # added for testing
+        - numpy.core._struct_ufunc_tests  # added for testing
+        - numpy.core._rational_tests      # added for testing
+        - numpy.core.umath                # added for testing
+        - numpy.core._umath_tests         # added for testing
+        - numpy.linalg.lapack_lite        # added for testing
+        - numpy.random.mtrand             # added for testing
         - numpy.core.multiarray
         - numpy.core.numeric
         - numpy.core.umath

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -164,7 +164,7 @@ about:
     NumPy is the fundamental package needed for scientific computing with Python.
   doc_url: https://numpy.org/doc/stable/reference/
   dev_url: https://github.com/numpy/numpy
-  doc_source_url: https://github.com/numpy/numpy/tree/main/doc
+  doc_source_url: https://github.com/numpy/numpy/tree/main/doc 
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
`numpy` version `1.23.3`
1. - [x] Check the upstream
    https://github.com/numpy/numpy/tree/v1.23.3
2. - [x] Check the pinnings
3. - [x] Check the changelogs

    https://github.com/numpy/numpy/tree/v1.23.3/doc/changelog

    https://github.com/numpy/numpy/blob/main/doc/changelog/1.23.2-changelog.rst

    https://github.com/numpy/numpy/blob/main/doc/changelog/1.23.3-changelog.rst

    There are currently no mayor braking issues mentioned in the changelog. 
    The changes mentioned were bug fixes or new features.

4. - [x] Additional research
    https://github.com/conda-forge/numpy-feedstock/issues

    There are some known issues mentioned on the upstream at the time of the review, however the issues mentioned do not seem to be breaking issues. 

5. - [x] Verify the `dev_url`
    https://github.com/numpy/numpy
6. - [x] Verify the `doc_url`

    redirect to the following URL:
     https://numpy.org/doc/stable/reference/

     redirect to the following URL:
     https://github.com/numpy/numpy/tree/main/doc

7. - [x] License is `spdx` compliant
    BSD-3-Clause
8. - [x] License family is present
    `License_family` corrections were needed due to earlier misspellings

9. - [x] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`
    setuptools
11. - [x] Verify if the package needs `wheel`
    wheel

12. - [x] `pip` in the test section
    Not needed in this case, the upstream test suit was used instead.
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
15. - [x] Verify that private modules are not mentioned on the recipe For example: (_private_module)

Results:
-


Based on the research findings and the results we can conclude
that it is relatively safe to update `numpy` to version `1.23.3`
