### PR TITLE
numpy version 1.23.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.23.4" %}
+{% set version = "1.23.5" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: ed2cc92af0efad20198638c69bb0fc2870a58dabfba6eb722c933b48556c686c
+  sha256: 1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a 
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,8 +135,6 @@ outputs:
         - pytest-cov
         - pytest-xdist
         - hypothesis >=6.29.3
-        # workaround for python/cpython#98706
-        - importlib_metadata >=4.13  # [py==311]
         - pytz >=2021.3
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ outputs:
       entry_points:
         - f2py = numpy.f2py.f2py2e:main  # [win]
       missing_dso_whitelist:  # [s390x]
-  - $RPATH/ld64.so.1    # [s390x]
+        - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.23.5" %}
+{% set version = "1.23.4" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: 1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a 
+  sha256: ed2cc92af0efad20198638c69bb0fc2870a58dabfba6eb722c933b48556c686c
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ outputs:
     script: install_base.bat  # [win]
     build:
       entry_points:
-        - f2py = numpy.f2py.f2py2e:main  # [win]
+        - f2py = numpy.f2py.f2py2e:main
       missing_dso_whitelist:  # [s390x]
         - $RPATH/ld64.so.1    # [s390x]
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,9 @@ outputs:
     script: install_base.bat  # [win]
     build:
       entry_points:
-        - f2py = numpy.f2py.f2py2e:main
+        - f2py = numpy.f2py.f2py2e:main  # [win]
       missing_dso_whitelist:  # [s390x]
-        - $RPATH/ld64.so.1    # [s390x]
+  - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -135,6 +135,8 @@ outputs:
         - pytest-cov
         - pytest-xdist
         - hypothesis >=6.29.3
+        # workaround for python/cpython#98706
+        - importlib_metadata >=4.13  # [py==311]
         - pytz >=2021.3
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
@@ -152,6 +154,7 @@ outputs:
       imports:
         - numpy
         - numpy.core.multiarray
+        - numpy.core.multiarray_tests  #testing
         - numpy.core.numeric
         - numpy.core.umath
         - numpy.linalg.lapack_lite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.23.4" %}
+{% set version = "1.23.5" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: ed2cc92af0efad20198638c69bb0fc2870a58dabfba6eb722c933b48556c686c
+  sha256: 1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a 
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]
@@ -152,7 +152,6 @@ outputs:
       imports:
         - numpy
         - numpy.core.multiarray
-        - numpy.core.multiarray_tests  #testing
         - numpy.core.numeric
         - numpy.core.umath
         - numpy.linalg.lapack_lite


### PR DESCRIPTION
Minor version bump from 1.23.4 to 1.23.5
- updated version number
- updated SHA