### PR TITLE
NumPy v1.22 for ppc64le py3.10

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,9 +3,3 @@
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: no
-c_compiler_version:        # [ppc64le]
-  - 8.2.0                  # [ppc64le]
-cxx_compiler_version:      # [ppc64le]
-  - 8.2.0                  # [ppc64le]
-fortran_compiler_version:  # [ppc64le]
-  - 8.2.0                  # [ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,6 +127,7 @@ outputs:
     # On osx-arm64: FAILED core/tests/test_limited_api.py::test_limited_api - subprocess.CalledProcessor
     {% set tests_to_skip = tests_to_skip + " or test_limited_api" %}   # [(osx and arm64)]
     {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}   # [(s390x)]
+    {% set tests_to_skip = tests_to_skip + " or test_generic_alias" %}   # [(ppc64le)]
 
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -126,7 +126,7 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_new_policy" %}   # [ppc64le or s390x or arm64]
     # On osx-arm64: FAILED core/tests/test_limited_api.py::test_limited_api - subprocess.CalledProcessor
     {% set tests_to_skip = tests_to_skip + " or test_limited_api" %}   # [(osx and arm64)]
-    {% set tests_to_skip = tests_to_skip + " or " test_gcd_overflow%}   # [(s390x)]
+    {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}   # [(s390x)]
 
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,6 @@ outputs:
     # On osx-arm64: FAILED core/tests/test_limited_api.py::test_limited_api - subprocess.CalledProcessor
     {% set tests_to_skip = tests_to_skip + " or test_limited_api" %}   # [(osx and arm64)]
     {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}   # [(s390x)]
-    {% set tests_to_skip = tests_to_skip + " or test_generic_alias" %}   # [(ppc64le)]
 
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -126,6 +126,8 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_new_policy" %}   # [ppc64le or s390x or arm64]
     # On osx-arm64: FAILED core/tests/test_limited_api.py::test_limited_api - subprocess.CalledProcessor
     {% set tests_to_skip = tests_to_skip + " or test_limited_api" %}   # [(osx and arm64)]
+    {% set tests_to_skip = tests_to_skip + " or " test_gcd_overflow%}   # [(s390x)]
+
 
     test:
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
 
 build:
-  number: 0
+  number: 1
   # numpy 1.20.0 no longer supports Python 3.6: https://numpy.org/doc/stable/release/1.20.0-notes.html
   # "The Python versions supported for this release are 3.7-3.9, support for Python 3.6 has been dropped"
   # numpy 1.21.x set Python upper bound <3.11, see https://github.com/numpy/numpy/commit/1e8d6a83985f3191c63963414981743adc4353cf


### PR DESCRIPTION
## NumPy 1.22 (on 3.10 and ppc64le) on ppc64le

**Jira ticket:** 
[PKG-40](https://anaconda.atlassian.net/browse/PKG-40)

The upstream data:
Anaconda recipe for 1.22: https://github.com/AnacondaRecipes/numpy-feedstock/tree/numpy122
conda_build_config.yaml:  https://github.com/AnacondaRecipes/numpy-feedstock/blob/numpy122/recipe/conda_build_config.yaml
Upstream repo for 1.22: https://github.com/numpy/numpy/tree/maintenance/1.22.x

**_Actions:_**
- bumped build number
- In order to build `ppc36le`, removed `8.2` pinnings from conda_build_config.yaml, and used the latest compiler versions.

