### PR TITLE
numpy 1.24.2

### DIFF
--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -21,9 +21,10 @@ case "$UNAME_M" in
 esac
 
 case "$UNAME_M" in
-    ppc64*)
-        # Optimizations trigger compiler bug.
-        EXTRA_OPTS="--no-use-pep517 --global-option=build --global-option=--cpu-dispatch=min"
+    s390x*)
+        # Try to disable z14.
+        CFLAGS="-march=native"
+        CXXFLAGS="-march=native"
         ;;
     *)
         EXTRA_OPTS=""

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.23.5" %}
+{% set version = "1.24.2" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: 1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a 
+  sha256: 003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22 
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index e98b459..c2ef0a3 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.23.5" %}
+{% set version = "1.24.2" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: 1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a 
+  sha256: 003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22 
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]

```

**Jira ticket:** [PKG-1105
PKG-950
PKG-865
PKG-798
PKG-770
PKG-739
PKG-611
PKG-405
PKG-351
PKG-317
PKG-313
PKG-259
PKG-239
PKG-91
PKG-40
SRV-465](https://anaconda.atlassian.net/browse/PKG-1105
https://anaconda.atlassian.net/browse/PKG-950
https://anaconda.atlassian.net/browse/PKG-865
https://anaconda.atlassian.net/browse/PKG-798
https://anaconda.atlassian.net/browse/PKG-770
https://anaconda.atlassian.net/browse/PKG-739
https://anaconda.atlassian.net/browse/PKG-611
https://anaconda.atlassian.net/browse/PKG-405
https://anaconda.atlassian.net/browse/PKG-351
https://anaconda.atlassian.net/browse/PKG-317
https://anaconda.atlassian.net/browse/PKG-313
https://anaconda.atlassian.net/browse/PKG-259
https://anaconda.atlassian.net/browse/PKG-239
https://anaconda.atlassian.net/browse/PKG-91
https://anaconda.atlassian.net/browse/PKG-40
https://anaconda.atlassian.net/browse/SRV-465) (numpy
numpy
numpy
numpy
numpy

numpy
scipy
numpy


numpy
numpy
numpy
numpy
numpy-financial-1.24.2
1.24.1
1.24
1.23.5


1.23.4
1.7.3
1.23.3


1.23.2


1.22.3
1.0.0)

**The upstream data:**
Github releases:  https://github.com/numpy/numpy/releases
[Diff between the latest and previous upstream releases](https://github.com/numpy/numpy/compare/1.23.5...1.24.2)
Requirements:
 * setup.cfg:  https://github.com/numpy/numpy/blob/v1.24.2/setup.cfg
 * setup.py:  https://github.com/numpy/numpy/blob/v1.24.2/setup.py
 *  pyproject.toml:  https://github.com/numpy/numpy/blob/v1.24.2/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: medium | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.24.2
 * Release on PyPi:
    * version: 1.24.2
    * date: 2023-02-05T20:12:05
* [PyPi history](https://pypi.org/project/numpy/#history)
 * Popularity: 
    * 3 months downloads: 7766683.0
    * All time:  48838300 downloads -  numpy  1.24.2  The fundamental package for scientific computing with Python.  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
4. - [ ] Verify if the package needs `setuptools`
    setuptools
setuptools
setuptools
6. - [ ] Verify if the package needs `wheel`
    wheel
wheel
8. - [ ] NO `pip` in test
    
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE.txt is present

14. - [x] license_family BSD is present
16. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/numpy-feedstock/recipe/meta.yaml
Dependencies: ['numpy-base', 'cython >=0.29.30,<3.0>=0.29.24', 'pip', 'setuptools <60.0.0<60.0.0', 'python', 'wheel >=0.37.0>=0.37.0']


noarch:
- py3.7:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.8:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.9:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.10:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24

linux-64:
- py3.7:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.8:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.9:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.10:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24

linux-ppc64le:
- py3.7:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.8:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.9:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.10:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24

linux-s390x:
- py3.7:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.8:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.9:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.10:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24

osx-64:
- py3.7:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.8:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.9:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.10:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24

osx-arm64:
- py3.8:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.9:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.10:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24

win-64:
- py3.7:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.8:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.9:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24
- py3.10:  invalid package specification: cython >=0.29.30,<3.0>=0.29.24

</details>

**Package Build Score: 'NoneType' object has no attribute 'get'**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/numpy-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/numpy-feedstock/tree/1.24.2)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/numpy)
* [Diff between upstream and feature branch](https://github.com/conda-forge/numpy-feedstock/compare/main...AnacondaRecipes:1.24.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/numpy-feedstock/compare/master...AnacondaRecipes:1.24.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/numpy-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.24.2 git@github.com:AnacondaRecipes/numpy-feedstock.git
```
