### PR TITLE
Pkg 865v2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,3 +3,8 @@
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: no
+
+c_compiler:    # [win]
+  - vs2019     # [win]
+cxx_compiler:  # [win]
+  - vs2019     # [win]

--- a/recipe/install_base.bat
+++ b/recipe/install_base.bat
@@ -2,7 +2,7 @@
 
 COPY %PREFIX%\site.cfg site.cfg
 
-%PYTHON% -m pip install --no-deps --ignore-installed -v .
+%PYTHON% -m pip install --no-deps --ignore-installed  -v .
 if errorlevel 1 exit 1
 
 XCOPY %RECIPE_DIR%\f2py.bat %SCRIPTS% /s /e

--- a/recipe/install_base.bat
+++ b/recipe/install_base.bat
@@ -2,7 +2,7 @@
 
 COPY %PREFIX%\site.cfg site.cfg
 
-%PYTHON% -m pip install --no-deps --ignore-installed  -v .
+%PYTHON% -m pip install --no-deps --ignore-installed --no-build-isolation -v .
 if errorlevel 1 exit 1
 
 XCOPY %RECIPE_DIR%\f2py.bat %SCRIPTS% /s /e

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -19,7 +19,7 @@ case "$UNAME_M" in
         # gcc 11 has issue with vectorization on s390x
         export CFLAGS="${CFLAGS} -mno-vx"
         export CXXFLAGS="${CXXFLAGS} -mno-vx"
-        cp $RECIPE_DIR/s390x_site.cfg site.cfg
+        cp $PREFIX/site.cfg site.cfg
         ;;
     *)
         cp $PREFIX/site.cfg site.cfg

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -15,6 +15,12 @@ case "$UNAME_M" in
     aarch64)
         cp $RECIPE_DIR/aarch_site.cfg site.cfg
         ;;
+    s390x*)
+        # gcc 11 has issue with vectorization on s390x
+        export CFLAGS="${CFLAGS} -mno-vx"
+        export CXXFLAGS="${CXXFLAGS} -mno-vx"
+        cp $RECIPE_DIR/s390x_site.cfg site.cfg
+        ;;
     *)
         cp $PREFIX/site.cfg site.cfg
         ;;
@@ -30,4 +36,4 @@ case "$UNAME_M" in
         ;;
 esac
 
-${PYTHON} -m pip install --no-deps --ignore-installed $EXTRA_OPTS -v .
+${PYTHON} -m pip install --no-deps  --no-build-isolation --ignore-installed $EXTRA_OPTS -v .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.23.5" %}
+{% set version = "1.24.2" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: 1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a 
+  sha256: 003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22  
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]
@@ -17,10 +17,9 @@ source:
 
 build:
   number: 0
-  # numpy 1.20.0 no longer supports Python 3.6: https://numpy.org/doc/stable/release/1.20.0-notes.html
-  # "The Python versions supported for this release are 3.7-3.9, support for Python 3.6 has been dropped"
-  # numpy 1.21.x set Python upper bound <3.11, see https://github.com/numpy/numpy/commit/1e8d6a83985f3191c63963414981743adc4353cf
-  skip: True  # [(blas_impl == 'openblas' and win) or py<38]
+  # numpy 1.24.2 no longer supports Python 3.7: https://numpy.org/devdocs/release/1.24.0-notes.html
+  # "This release supports Python versions 3.8-3.11"
+  skip: True  # [(blas_impl == 'openblas' and win)]
   force_use_keys:
     - python
 
@@ -114,6 +113,13 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_overrides" %}  # [blas_impl == 'mkl']
     # https://github.com/numpy/numpy/issues/15243
     {% set tests_to_skip = tests_to_skip + " or test_loss_of_precision" %}  # [s390x or ppc64le]
+    # https://github.com/numpy/numpy/issues/3858 - could be related
+    {% set tests_to_skip = tests_to_skip + " or test_big_arrays" %}  # [s390x or ppc64le]
+
+    #skip simd tests because  -mno-vx option for s390
+    {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]
+
+
     # It should be fixed by https://github.com/numpy/numpy/issues/20426
     # but it still fails on some platforms.
     {% set tests_to_skip = tests_to_skip + " or test_new_policy" %}   # [s390x or ppc64le or (osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,7 +114,7 @@ outputs:
     # https://github.com/numpy/numpy/issues/15243
     {% set tests_to_skip = tests_to_skip + " or test_loss_of_precision" %}  # [s390x or ppc64le]
     # https://github.com/numpy/numpy/issues/3858 - could be related
-    {% set tests_to_skip = tests_to_skip + " or test_big_arrays" %}  # [s390x or ppc64le or linux64]
+    # {% set tests_to_skip = tests_to_skip + " or test_big_arrays" %}  # [s390x or ppc64le or linux64]
 
     #skip simd tests because  -mno-vx option for s390
     {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ outputs:
         - python
         - pip
         - packaging  # [osx and arm64]
-        - cython >=0.29.30, <3.0
+        - cython >=0.29.30,<3.0
         - setuptools <60.0.0
         - wheel >=0.37.0
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
@@ -79,7 +79,7 @@ outputs:
       host:
         - python
         - packaging  # [osx and arm64]
-        - cython >=0.29.30, <3.0
+        - cython >=0.29.30,<3.0
         - setuptools <60.0.0
         - wheel >=0.37.0
         # these import blas metapackages to ensure consistency with downstream libs that also use blas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.24.2" %}
+{% set version = "1.24.3" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: 003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22  
+  sha256: ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155  
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]
@@ -47,7 +47,7 @@ outputs:
         - python
         - pip
         - packaging  # [osx and arm64]
-        - cython >=0.29.30,<3.0
+        - cython >=0.29.30, <3.0
         - setuptools <60.0.0
         - wheel >=0.37.0
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
@@ -79,7 +79,7 @@ outputs:
       host:
         - python
         - packaging  # [osx and arm64]
-        - cython >=0.29.24
+        - cython >=0.29.30, <3.0
         - setuptools <60.0.0
         - wheel >=0.37.0
         # these import blas metapackages to ensure consistency with downstream libs that also use blas
@@ -114,7 +114,7 @@ outputs:
     # https://github.com/numpy/numpy/issues/15243
     {% set tests_to_skip = tests_to_skip + " or test_loss_of_precision" %}  # [s390x or ppc64le]
     # https://github.com/numpy/numpy/issues/3858 - could be related
-    {% set tests_to_skip = tests_to_skip + " or test_big_arrays" %}  # [s390x or ppc64le]
+    {% set tests_to_skip = tests_to_skip + " or test_big_arrays" %}  # [s390x or ppc64le or linux64]
 
     #skip simd tests because  -mno-vx option for s390
     {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,7 +114,7 @@ outputs:
     # https://github.com/numpy/numpy/issues/15243
     {% set tests_to_skip = tests_to_skip + " or test_loss_of_precision" %}  # [s390x or ppc64le]
     # https://github.com/numpy/numpy/issues/3858 - could be related
-    # {% set tests_to_skip = tests_to_skip + " or test_big_arrays" %}  # [s390x or ppc64le or linux64]
+    {% set tests_to_skip = tests_to_skip + " or test_big_arrays" %}  # [s390x]
 
     #skip simd tests because  -mno-vx option for s390
     {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -168,13 +168,11 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  license_url: https://github.com/numpy/numpy/blob/main/LICENSE.txt
   summary: Array processing for numbers, strings, records, and objects.
   description: |
     NumPy is the fundamental package needed for scientific computing with Python.
   doc_url: https://numpy.org/doc/stable/reference/
   dev_url: https://github.com/numpy/numpy
-  doc_source_url: https://github.com/numpy/numpy/tree/main/doc 
 
 extra:
   recipe-maintainers:

--- a/recipe/s390x_site.cfg
+++ b/recipe/s390x_site.cfg
@@ -1,0 +1,6 @@
+[openblas]
+libraries = openblas
+library_dirs = $PREFIX/lib
+include_dirs = $PREFIX/include
+runtime_library_dirs = $PREFIX/lib
+

--- a/recipe/s390x_site.cfg
+++ b/recipe/s390x_site.cfg
@@ -1,6 +1,0 @@
-[openblas]
-libraries = openblas
-library_dirs = $PREFIX/lib
-include_dirs = $PREFIX/include
-runtime_library_dirs = $PREFIX/lib
-


### PR DESCRIPTION
changes from 1.23.5
- dropped support for python 3.7
- cython >=0.29.30, <3.0
- turned off SIMD  on S390 gcc, due to compiler bug
- skipped big_arrays_test on s390 - still a problem with crashing tests
- skipped SIMD tests on s390
- updated windows compiler to VS2019, as older version does not support "restrict" keyword


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
