### PR TITLE
Np119/mkl2023 - skip CI

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+# upload to a temp channel for testing
+channels:
+  cbouss: mkl2023 

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-# upload to a temp channel for testing
-channels:
-  cbouss: mkl2023 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,3 +13,5 @@ fortran_compiler_version:  # [linux or osx]
   - 11.2.0                 # [linux or osx]
 openblas:
   - 0.3.20
+mkl:
+  - 2023.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,6 +110,9 @@ outputs:
     # behaviour change in MKL 2022, see
     # https://github.com/numpy/numpy/issues/18914
     {% set tests_to_skip = tests_to_skip + " or (test_linalg and TestCond and test_nan)" %}
+    # behaviour change in MKL 2022? 
+    # Arrays are not equal x: array([ 55, 145, 235,  69], dtype=uint8) vs y: array([ 55, 145, 235, 255], dtype=uint8)
+    {% set tests_to_skip = tests_to_skip + " or (test_einsum_sums_uint8)" %} # [osx and blas_impl == 'mkl']
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,6 +107,9 @@ outputs:
     # Reported here but never resolved?
     # https://github.com/numpy/numpy/issues/16046
     {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}  # [s390x]
+    # behaviour change in MKL 2022, see
+    # https://github.com/numpy/numpy/issues/18914
+    {% set tests_to_skip = tests_to_skip + " or (test_linalg and TestCond and test_nan)" %}
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,7 @@ source:
     - 0005-test-ctypeslib-py37.patch  # [win and py<38]
 
 build:
-  number: 4
-  # trigger 1
+  number: 5
   skip: True  # [(blas_impl == 'openblas' and win) or py<36 or py>39]
   force_use_keys:
     - python
@@ -57,10 +56,7 @@ outputs:
     # When building out the initial package set for a new Python version the
     # recommendataion is to build numpy-base but not numpy, then build
     # mkl_fft and mkl_random, and then numpy.
-    # The false line will build numpy-base only
-    # {% if false %}
-    # The true line will build numpy-base and numpy
-    {% if true %}
+    {% if only_build_numpy_base != 'yes' %}
     test:
       commands:
         - test -e $SP_DIR/numpy/distutils/site.cfg     # [unix]


### PR DESCRIPTION
Changes:

1.19 built against mkl 2023
increased build number
skip 2 tests failing with mkl 2023

Built on dev instance along with mkl-service, mkl_random, mkl_fft.
Uploaded to label cbouss/label/mkl2023.