### PR TITLE
Np123/mkl2023 - skip CI

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,3 +3,5 @@
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: no
+mkl:
+  - 2023.*

--- a/recipe/install_base.bat
+++ b/recipe/install_base.bat
@@ -2,7 +2,7 @@
 
 COPY %PREFIX%\site.cfg site.cfg
 
-%PYTHON% -m pip install --no-deps --ignore-installed -v .
+%PYTHON% -m pip install --no-deps --no-build-isolation --ignore-installed -v .
 if errorlevel 1 exit 1
 
 XCOPY %RECIPE_DIR%\f2py.bat %SCRIPTS% /s /e

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -30,4 +30,4 @@ case "$UNAME_M" in
         ;;
 esac
 
-${PYTHON} -m pip install --no-deps --ignore-installed $EXTRA_OPTS -v .
+${PYTHON} -m pip install --no-deps --no-build-isolation --ignore-installed $EXTRA_OPTS -v .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,8 @@ source:
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
 
 build:
-  number: 0
-  # numpy 1.20.0 no longer supports Python 3.6: https://numpy.org/doc/stable/release/1.20.0-notes.html
-  # "The Python versions supported for this release are 3.7-3.9, support for Python 3.6 has been dropped"
-  # numpy 1.21.x set Python upper bound <3.11, see https://github.com/numpy/numpy/commit/1e8d6a83985f3191c63963414981743adc4353cf
+  number: 1
+  # The Python versions supported for this release are 3.8-3.11 - 3.12 may work in the future.
   skip: True  # [(blas_impl == 'openblas' and win) or py<38]
   force_use_keys:
     - python


### PR DESCRIPTION
Changes:

1.23 built against mkl 2023
increased build number

Built on dev instance along with mkl-service, mkl_random, mkl_fft.
Uploaded to label cbouss/label/mkl2023.