### PR TITLE
Np124/mkl2023 - skip CI

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,3 +8,6 @@ c_compiler:    # [win]
   - vs2019     # [win]
 cxx_compiler:  # [win]
   - vs2019     # [win]
+
+  mkl:
+  - 2023.*

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,5 +9,5 @@ c_compiler:    # [win]
 cxx_compiler:  # [win]
   - vs2019     # [win]
 
-  mkl:
+mkl:
   - 2023.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
 
 build:
-  number: 0
+  number: 1
   # numpy 1.24.2 no longer supports Python 3.7: https://numpy.org/devdocs/release/1.24.0-notes.html
   # "This release supports Python versions 3.8-3.11"
   skip: True  # [(blas_impl == 'openblas' and win)]


### PR DESCRIPTION
Changes:

1.23 built against mkl 2023
increased build number

Built on dev instance along with mkl-service, mkl_random, mkl_fft.
Uploaded to label cbouss/label/mkl2023.