### PR TITLE
PKG-2241 - numpy 1.25.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/0004-disable-autorun-for-cmd-test.patch   # [win]
     - patches/0005-array_coercion_fix.patch             # [blas_impl == "mkl" and win]
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
-    - patches/0007-enable-meson-build.patch             # [py>311] https://github.com/numpy/numpy/blob/v1.25.0/building_with_meson.md
+    - patches/0007-enable-meson-build.patch             # [py>=312] https://github.com/numpy/numpy/blob/v1.25.0/building_with_meson.md
 
 build:
   number: 0
@@ -49,8 +49,9 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.0
-        - setuptools <60.0.0  # [py<=311]
+        - setuptools <60.0.0    # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
+        - meson >=1.1.0         # [py>=312]
         - wheel
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
@@ -63,8 +64,8 @@ outputs:
     {% if only_build_numpy_base != 'yes' %}
     test:
       commands:
-        - test -e $SP_DIR/numpy/distutils/site.cfg     # [unix]
-        - IF NOT EXIST %SP_DIR%\numpy\distutils\site.cfg exit 1  # [win]
+        - test -e $SP_DIR/numpy/distutils/site.cfg     # [unix and py<=311]
+        - IF NOT EXIST %SP_DIR%\numpy\distutils\site.cfg exit 1  # [win and py<=311]
 
   # numpy is a metapackage that may include mkl_fft and mkl_random both of
   # which require numpy-base to build
@@ -81,8 +82,9 @@ outputs:
       host:
         - python
         - cython >=0.29.34,<3.0
-        - setuptools <60.0.0  # [py<=311]
+        - setuptools <60.0.0    # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
+        - meson >=1.1.0         # [py>=312]
         - wheel
         # these import blas metapackages to ensure consistency with downstream libs that also use blas
         - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.24.3" %}
+{% set version = "1.25.0rc1" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155  
+  sha256: 224e8862a1cd357eede831b270b9e6c51d2cbc2bb5cc2e2b8d0c76d52cbd1edc  
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]
@@ -14,12 +14,14 @@ source:
     - patches/0004-disable-autorun-for-cmd-test.patch   # [win]
     - patches/0005-array_coercion_fix.patch             # [blas_impl == "mkl" and win]
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
+    - patches/0007-enable-meson-build.patch             # [py>311] https://github.com/numpy/numpy/blob/v1.25.0rc1/building_with_meson.md
 
 build:
-  number: 1
-  # numpy 1.24.2 no longer supports Python 3.7: https://numpy.org/devdocs/release/1.24.0-notes.html
-  # "This release supports Python versions 3.8-3.11"
+  number: 0
+  # numpy 1.25 no longer supports Python 3.8: https://numpy.org/devdocs/release/1.25.0-notes.html
+  # "This release supports Python versions 3.9-3.11"
   skip: True  # [(blas_impl == 'openblas' and win)]
+  skip: True  # [py<39]
   force_use_keys:
     - python
 
@@ -47,9 +49,10 @@ outputs:
         - python
         - pip
         - packaging  # [osx and arm64]
-        - cython >=0.29.30,<3.0
-        - setuptools <60.0.0
-        - wheel >=0.37.0
+        - cython >=0.29.34,<3.0
+        - setuptools <60.0.0  # [py<=311]
+        - meson-python >=0.10.0 # [py>=312]
+        - wheel
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
       run:
@@ -92,51 +95,13 @@ outputs:
         - mkl_fft  # [blas_impl == 'mkl']
         - mkl_random # [blas_impl == 'mkl' and (not win or vc>=14)]
     {% endif %}
+
     {% set tests_to_skip = "_not_a_real_test" %}
-    # Arrays are not equal?:
-    # E            x: array(2.236068, dtype=float32)
-    # E            y: array(2.236068, dtype=float32)
-     #{% set tests_to_skip = tests_to_skip + " or test_scalar_coercion_same_as_cast_and_assignment[float32]" %} # [ppc64le]
-     #{% set tests_to_skip = tests_to_skip + " or test_memory_store" %} # [ppc64le]
-     #
-    # any test that uses `sys.executable` has a chance to fail...
-    # this seems to be the related cause: https://github.com/conda/conda/issues/8305
-    # essentially older kernel versions + overlayfs = chance for corruption?
-    {% set tests_to_skip = tests_to_skip + " or test_sdot_bug_8577" %}          # [ppc64le or s390x]
-    {% set tests_to_skip = tests_to_skip + " or test_import_lazy_import" %}     # [ppc64le or s390x]
-    {% set tests_to_skip = tests_to_skip + " or test_full_reimport" %}          # [ppc64le or s390x]
-    {% set tests_to_skip = tests_to_skip + " or test_pep338" %}                 # [ppc64le or s390x]
-    {% set tests_to_skip = tests_to_skip + " or test_no_typing_extensions" %}   # [ppc64le or s390x]
-    # 2022/5/5: E       AssertionError: (131, 1.54987431981169249551435343964035e-09, 4.0035173453529620614007210953362e-19, 'arcsinh')
-    # Flawed test when using MKL
-    # https://github.com/numpy/numpy/issues/16769
-    {% set tests_to_skip = tests_to_skip + " or test_overrides" %}  # [blas_impl == 'mkl']
-    # https://github.com/numpy/numpy/issues/15243
-    {% set tests_to_skip = tests_to_skip + " or test_loss_of_precision" %}  # [s390x or ppc64le]
-    # https://github.com/numpy/numpy/issues/3858 - could be related
-    {% set tests_to_skip = tests_to_skip + " or test_big_arrays" %}  # [s390x]
-
-    #skip simd tests because  -mno-vx option for s390
-    {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]
-
-
-    # It should be fixed by https://github.com/numpy/numpy/issues/20426
-    # but it still fails on some platforms.
-    {% set tests_to_skip = tests_to_skip + " or test_new_policy" %}   # [s390x or ppc64le or (osx and arm64)]
-    # On osx-arm64: FAILED core/tests/test_limited_api.py::test_limited_api - subprocess.CalledProcessor
-    {% set tests_to_skip = tests_to_skip + " or test_limited_api" %}   # [osx and arm64]
-    # ?
-    {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}  # [s390x]
-    # ?
-    {% set tests_to_skip = tests_to_skip + " or test_herm_cases" %}  # [osx and arm64]
-    {% set tests_to_skip = tests_to_skip + " or test_generalized_herm_cases" %}  # [osx and arm64]
-    # ?
-    {% set tests_to_skip = tests_to_skip + " or test_partial_iteration_cleanup" %}  # [osx or win64]
 
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail
-        - setuptools <60.0.0
+        - pytz
         - pytest
         - pytest-cov
         - pytest-xdist
@@ -148,6 +113,7 @@ outputs:
         - nomkl  # [x86 and blas_impl != 'mkl']
         - typing-extensions >=4.2.0
         - mypy >=0.981
+        - cffi  # [py<310]
       commands:
         - f2py -h
         - python -c "import numpy; numpy.show_config()"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,9 +82,10 @@ outputs:
       host:
         - python
         - packaging  # [osx and arm64]
-        - cython >=0.29.30,<3.0
-        - setuptools <60.0.0
-        - wheel >=0.37.0
+        - cython >=0.29.34,<3.0
+        - setuptools <60.0.0  # [py<=311]
+        - meson-python >=0.10.0 # [py>=312]
+        - wheel
         # these import blas metapackages to ensure consistency with downstream libs that also use blas
         - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
         - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,6 +99,23 @@ outputs:
 
     {% set tests_to_skip = "_not_a_real_test" %}
 
+    # Flawed test when using MKL
+    # https://github.com/numpy/numpy/issues/16769
+    {% set tests_to_skip = tests_to_skip + " or test_overrides" %}  # [blas_impl == 'mkl']
+    # https://github.com/numpy/numpy/issues/15243
+    {% set tests_to_skip = tests_to_skip + " or test_loss_of_precision" %}  # [s390x]
+    # https://github.com/numpy/numpy/issues/3858 - could be related
+    {% set tests_to_skip = tests_to_skip + " or test_big_arrays" %}  # [s390x]
+
+    #skip simd tests because  -mno-vx option for s390
+    {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]
+
+    # It should be fixed by https://github.com/numpy/numpy/issues/20426
+    # but it still fails on some platforms.
+    {% set tests_to_skip = tests_to_skip + " or test_new_policy" %}   # [s390x]
+    # ?
+    {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}  # [s390x]
+    
     test:
       requires:
         - pip     # force installation or `test_api_importable` will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,9 +50,9 @@ outputs:
         - pip
         - cython >=0.29.34,<3.0
         - setuptools <60.0.0    # [py<=311]
+        - wheel                 # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
         - meson >=1.1.0         # [py>=312]
-        - wheel
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
       run:
@@ -83,9 +83,9 @@ outputs:
         - python
         - cython >=0.29.34,<3.0
         - setuptools <60.0.0    # [py<=311]
+        - wheel                 # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
         - meson >=1.1.0         # [py>=312]
-        - wheel
         # these import blas metapackages to ensure consistency with downstream libs that also use blas
         - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
         - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,6 @@ outputs:
       host:
         - python
         - pip
-        - packaging  # [osx and arm64]
         - cython >=0.29.34,<3.0
         - setuptools <60.0.0  # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
@@ -81,7 +80,6 @@ outputs:
         - armpl  # [aarch64]
       host:
         - python
-        - packaging  # [osx and arm64]
         - cython >=0.29.34,<3.0
         - setuptools <60.0.0  # [py<=311]
         - meson-python >=0.10.0 # [py>=312]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.25.0rc1" %}
+{% set version = "1.25.0" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: 224e8862a1cd357eede831b270b9e6c51d2cbc2bb5cc2e2b8d0c76d52cbd1edc  
+  sha256: f1accae9a28dc3cda46a91de86acf69de0d1b5f4edd44a9b0c3ceb8036dfff19  
   patches:
     - patches/0001-Obtain-and-prefer-custom-gfortran-from-env-variable.patch
     - patches/0002-intel_mkl-version.patch              # [blas_impl == "mkl"]
@@ -14,7 +14,7 @@ source:
     - patches/0004-disable-autorun-for-cmd-test.patch   # [win]
     - patches/0005-array_coercion_fix.patch             # [blas_impl == "mkl" and win]
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
-    - patches/0007-enable-meson-build.patch             # [py>311] https://github.com/numpy/numpy/blob/v1.25.0rc1/building_with_meson.md
+    - patches/0007-enable-meson-build.patch             # [py>311] https://github.com/numpy/numpy/blob/v1.25.0/building_with_meson.md
 
 build:
   number: 0

--- a/recipe/patches/0007-enable-meson-build.patch
+++ b/recipe/patches/0007-enable-meson-build.patch
@@ -1,0 +1,32 @@
+From a7218a2df4164b56ffddfb14edd322fe94ab179e Mon Sep 17 00:00:00 2001
+From: Charles Bousseau <cbousseau@anaconda.com>
+Date: Wed, 14 Jun 2023 11:31:27 -0400
+Subject: [PATCH] enable meson build
+See: https://github.com/numpy/numpy/blob/v1.25.0rc1/building_with_meson.md
+---
+ pyproject.toml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 759b538fb..6df577847 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -4,13 +4,13 @@
+ #build-backend = "mesonpy"
+ requires = [
+     # setuptools, wheel and Cython are needed for the setup.py based build
+-    "setuptools==59.2.0",
++    # "setuptools==59.2.0",
+     # `wheel` is needed for non-isolated builds, given that `meson-python`
+     # doesn't list it as a runtime requirement (at least in 0.11.0) - it's
+     # likely to be removed as a dependency in meson-python 0.12.0.
+     "wheel==0.38.1",
+     "Cython>=0.29.34,<3.0",
+-#    "meson-python>=0.10.0",
++    "meson-python>=0.10.0",
+ ]
+ 
+ #[project]
+-- 
+2.32.1 (Apple Git-133)
+

--- a/recipe/patches/0007-enable-meson-build.patch
+++ b/recipe/patches/0007-enable-meson-build.patch
@@ -1,32 +1,175 @@
-From a7218a2df4164b56ffddfb14edd322fe94ab179e Mon Sep 17 00:00:00 2001
+From 1a92e9d3120630405e82b15ee3754206a0233082 Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
-Date: Wed, 14 Jun 2023 11:31:27 -0400
-Subject: [PATCH] enable meson build
-See: https://github.com/numpy/numpy/blob/v1.25.0rc1/building_with_meson.md
+Date: Wed, 21 Jun 2023 16:59:35 -0400
+Subject: [PATCH] BLD: default to using meson-python as build backend
+See: https://github.com/numpy/numpy/blob/v1.25.0/building_with_meson.md
+And: https://github.com/numpy/numpy/commit/e3cb66a1f6d994288036026f42db63d1e70d9206
 ---
- pyproject.toml | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ numpy/tests/test_public_api.py |   4 -
+ pyproject.toml                 | 130 ++++++++++++++++-----------------
+ 2 files changed, 62 insertions(+), 72 deletions(-)
 
+diff --git a/numpy/tests/test_public_api.py b/numpy/tests/test_public_api.py
+index eaa89aa6f..39fda70b4 100644
+--- a/numpy/tests/test_public_api.py
++++ b/numpy/tests/test_public_api.py
+@@ -471,10 +471,6 @@ def check_importable(module_name):
+                              "{}".format(module_names))
+ 
+ 
+-@pytest.mark.xfail(
+-    hasattr(np.__config__, "_built_with_meson"),
+-    reason = "Meson does not yet support entry points via pyproject.toml",
+-)
+ @pytest.mark.xfail(
+     sysconfig.get_config_var("Py_DEBUG") is not None,
+     reason=(
 diff --git a/pyproject.toml b/pyproject.toml
-index 759b538fb..6df577847 100644
+index 759b538fb..ec615e06e 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -4,13 +4,13 @@
- #build-backend = "mesonpy"
+@@ -1,79 +1,73 @@
+ [build-system]
+ # Uncomment this line, the `meson-python` requires line, and the [project] and
+ # [project.urls] tables below in order to build with Meson by default
+-#build-backend = "mesonpy"
++build-backend = "mesonpy"
  requires = [
-     # setuptools, wheel and Cython are needed for the setup.py based build
+-    # setuptools, wheel and Cython are needed for the setup.py based build
 -    "setuptools==59.2.0",
-+    # "setuptools==59.2.0",
-     # `wheel` is needed for non-isolated builds, given that `meson-python`
-     # doesn't list it as a runtime requirement (at least in 0.11.0) - it's
-     # likely to be removed as a dependency in meson-python 0.12.0.
-     "wheel==0.38.1",
+-    # `wheel` is needed for non-isolated builds, given that `meson-python`
+-    # doesn't list it as a runtime requirement (at least in 0.11.0) - it's
+-    # likely to be removed as a dependency in meson-python 0.12.0.
+-    "wheel==0.38.1",
      "Cython>=0.29.34,<3.0",
 -#    "meson-python>=0.10.0",
 +    "meson-python>=0.10.0",
  ]
  
- #[project]
+-#[project]
+-#name = "numpy"
+-#
+-## Using https://peps.python.org/pep-0639/
+-## which is still in draft
+-#license = {text = "BSD-3-Clause"}
+-## Note: needed for Meson, but setuptools errors on it. Uncomment once Meson is default.
+-##license-files.paths = [
+-##    "LICENSE.txt",
+-##    "LICENSES_bundles.txt"
+-##]
+-#
+-#description = "Fundamental package for array computing in Python"
+-#authors = [{name = "Travis E. Oliphant et al."}]
+-#maintainers = [
+-#    {name = "NumPy Developers", email="numpy-discussion@python.org"},
+-#]
+-#requires-python = ">=3.9"
+-#readme = "README.md"
+-#classifiers = [
+-#    'Development Status :: 5 - Production/Stable',
+-#    'Intended Audience :: Science/Research',
+-#    'Intended Audience :: Developers',
+-#    'License :: OSI Approved :: BSD License',
+-#    'Programming Language :: C',
+-#    'Programming Language :: Python',
+-#    'Programming Language :: Python :: 3',
+-#    'Programming Language :: Python :: 3.9',
+-#    'Programming Language :: Python :: 3.10',
+-#    'Programming Language :: Python :: 3.11',
+-#    'Programming Language :: Python :: 3 :: Only',
+-#    'Programming Language :: Python :: Implementation :: CPython',
+-#    'Topic :: Software Development',
+-#    'Topic :: Scientific/Engineering',
+-#    'Typing :: Typed',
+-#    'Operating System :: Microsoft :: Windows',
+-#    'Operating System :: POSIX',
+-#    'Operating System :: Unix',
+-#    'Operating System :: MacOS',
+-#]
++[project]
++name = "numpy"
++
++# Using https://peps.python.org/pep-0639/
++# which is still in draft
++license = {text = "BSD-3-Clause"}
++# Note: needed for Meson, but setuptools errors on it. Uncomment once Meson is default.
++license-files.paths = [
++    "LICENSE.txt",
++    "LICENSES_bundles.txt"
++]
++
++description = "Fundamental package for array computing in Python"
++authors = [{name = "Travis E. Oliphant et al."}]
++maintainers = [
++    {name = "NumPy Developers", email="numpy-discussion@python.org"},
++]
++requires-python = ">=3.9"
++readme = "README.md"
++classifiers = [
++    'Development Status :: 5 - Production/Stable',
++    'Intended Audience :: Science/Research',
++    'Intended Audience :: Developers',
++    'License :: OSI Approved :: BSD License',
++    'Programming Language :: C',
++    'Programming Language :: Python',
++    'Programming Language :: Python :: 3',
++    'Programming Language :: Python :: 3.9',
++    'Programming Language :: Python :: 3.10',
++    'Programming Language :: Python :: 3.11',
++    'Programming Language :: Python :: 3 :: Only',
++    'Programming Language :: Python :: Implementation :: CPython',
++    'Topic :: Software Development',
++    'Topic :: Scientific/Engineering',
++    'Typing :: Typed',
++    'Operating System :: Microsoft :: Windows',
++    'Operating System :: POSIX',
++    'Operating System :: Unix',
++    'Operating System :: MacOS',
++]
+ #dynamic = ["version", "scripts"]
+-#
+-#[project.scripts]
+-## Note: this is currently dynamic, see setup.py. Can we get rid of that?
+-##       see commit f22a33b71 for rationale for dynamic behavior
+-#'f2py = numpy.f2py.f2py2e:main'
+-#'f2py3 = numpy.f2py.f2py2e:main'
+-#'f2py3.MINOR_VERSION = numpy.f2py.f2py2e:main'
+-#
+-# When enabling this stanza, make sure to remove the meson-specific xfail from
+-# numpy/tests/test_public_api.py
+-#[project.entry-points]
+-#'array_api': 'numpy = numpy.array_api'
+-#'pyinstaller40': 'hook-dirs = numpy:_pyinstaller_hooks_dir'
+-#
+-#[project.urls]
+-#homepage = "https://numpy.org"
+-#documentation = "https://numpy.org/doc/"
+-#source = "https://github.com/numpy/numpy"
+-#download = "https://pypi.org/project/numpy/#files"
+-#tracker = "https://github.com/numpy/numpy/issues"
++
++[project.scripts]
++# Note: this is currently dynamic, see setup.py. Can we get rid of that?
++#       see commit f22a33b71 for rationale for dynamic behavior
++f2py = 'numpy.f2py.f2py2e:main'
++f2py3 = 'numpy.f2py.f2py2e:main'
++#f2py3.MINOR_VERSION = 'numpy.f2py.f2py2e:main'
++
++[project.entry-points.array_api]
++numpy = 'numpy.array_api'
++
++[project.entry-points.pyinstaller40]
++hook-dirs = 'numpy:_pyinstaller_hooks_dir'
++
++[project.urls]
++homepage = "https://numpy.org"
++documentation = "https://numpy.org/doc/"
++source = "https://github.com/numpy/numpy"
++download = "https://pypi.org/project/numpy/#files"
++tracker = "https://github.com/numpy/numpy/issues"
+ 
+ [tool.towncrier]
+     # Do no set this since it is hard to import numpy inside the source directory
 -- 
 2.32.1 (Apple Git-133)
 


### PR DESCRIPTION
Changes:
- Update to 1.25.0
- enable meson build for py>311
- clean test skip section

Release note: https://github.com/numpy/numpy/releases/tag/v1.25.0
https://github.com/numpy/numpy/tree/v1.25.0

https://github.com/numpy/numpy/blob/v1.25.0/pyproject.toml#L1
https://github.com/numpy/numpy/blob/v1.25.0/setup.py
https://github.com/numpy/numpy/blob/v1.25.0/test_requirements.txt