### PR TITLE
ci skip comment out mkl_fft and mkl_random

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,8 +93,9 @@ outputs:
         - python
         - {{ pin_subpackage('numpy-base', exact=True) }}
         # openblas or mkl runtime included with run_exports
-        - mkl_fft  # [blas_impl == 'mkl']
-        - mkl_random # [blas_impl == 'mkl' and (not win or vc>=14)]
+        # current mkl_fft and mkl_random are not buildable for python 3.12
+        - mkl_fft  # [blas_impl == 'mkl' and (py<312)]
+        - mkl_random # [blas_impl == 'mkl' and (not win or vc>=14) and (py<312)]
     {% endif %}
 
     {% set tests_to_skip = "_not_a_real_test" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,8 +94,8 @@ outputs:
         - {{ pin_subpackage('numpy-base', exact=True) }}
         # openblas or mkl runtime included with run_exports
         # current mkl_fft and mkl_random are not buildable for python 3.12
-        - mkl_fft  # [blas_impl == 'mkl' and (py<312)]
-        - mkl_random # [blas_impl == 'mkl' and (not win or vc>=14) and (py<312)]
+        - mkl_fft  # [blas_impl == 'mkl' and py<312]
+        - mkl_random # [blas_impl == 'mkl' and (not win or vc>=14) and py<312]
     {% endif %}
 
     {% set tests_to_skip = "_not_a_real_test" %}


### PR DESCRIPTION
Changes:
- comment out mkl_fft and mkl_random when py>=312 as these need numpy.disutils which is not available on 3.12.
- the build number is not incremented as the 3.12 build has not been published yet.