### PR TITLE
Version 1.26.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.26.2" %}
+{% set version = "1.26.3" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea  
+  sha256: 697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4
   patches:                                                # [blas_impl == "mkl" or s390x]
     - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
     - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]


### PR DESCRIPTION
numpy 1.26.3

**Destination channel:** defaults

### Links

- [PKG-3722](https://anaconda.atlassian.net/browse/PKG-3722)
- [Upstream repository](https://github.com/numpy/numpy/tree/v1.26.3)
- [Upstream changelog/diff](https://github.com/numpy/numpy/releases)

### Explanation of changes:

- Bump version to `1.26.3`

[PKG-3722]: https://anaconda.atlassian.net/browse/PKG-3722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ