### PR TITLE
Version 1.26.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+aggregate_branch: 3.12
+
+channels:
+  - https://staging.continuum.io/prefect/fs/meson-python-feedstock/pr6/766a71e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-  - https://staging.continuum.io/prefect/fs/meson-python-feedstock/pr6/766a71e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.26.3" %}
+{% set version = "1.26.4" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: 697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4
+  sha256: 2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010
   patches:                                                # [blas_impl == "mkl" or s390x]
     - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
     - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,7 +100,7 @@ outputs:
         - pytest-cov >=4.1.0
         - pytest-xdist
         - hypothesis >=6.81.1
-        - pytz >=2023.3
+        - pytz >=2023.3.post1
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -164,7 +164,9 @@ about:
   home: https://numpy.org/
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE.txt
+  license_file:
+    - LICENSE.txt
+    - LICENSES_bundled.txt
   summary: Array processing for numbers, strings, records, and objects.
   description: |
     NumPy is the fundamental package needed for scientific computing with Python.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,13 +39,14 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - armpl  # [aarch64]        
+        - armpl  # [aarch64]
         - ninja-base
         - pkg-config
       host:
         - python
         - pip
         - cython >=0.29.34,<3.1
+        - meson-python >=0.15.0,<0.16.0
         - python-build
         # dependencies of vendored meson-python
         - pyproject-metadata >=0.7.1
@@ -57,7 +58,7 @@ outputs:
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
       run:
         - python
-  
+
   # When building out the initial package set for a new Python version / MKL version the
   # recommendation is to build numpy-base but not numpy, then build
   # mkl_fft and mkl_random, and then numpy.
@@ -95,7 +96,7 @@ outputs:
     # https://github.com/numpy/numpy/issues/16046
     {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}  # [s390x]
     # skip simd tests because vxe2 feature is not detected when running from prefect
-    {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]   
+    {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]
 
     test:
       requires:
@@ -182,4 +183,4 @@ extra:
     - pelson
     - rgommers
     - ocefpaf
-    - chenghlee 
+    - chenghlee

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,11 +48,6 @@ outputs:
         - cython >=0.29.34,<3.1
         - meson-python >=0.15.0,<0.16.0
         - python-build
-        # dependencies of vendored meson-python
-        - pyproject-metadata >=0.7.1
-        - tomli >=1.0.0         # [py<311]
-        - setuptools >=60.0     # [py>=312]
-        - colorama              # [win]
         # blas
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]


### PR DESCRIPTION
numpy 1.26.4

**Destination channel:** defaults

### Links

- [PKG-4012](https://anaconda.atlassian.net/browse/PKG-4012)
- [Upstream repository](https://github.com/numpy/numpy/tree/v1.26.4)
- [Upstream changelog/diff](https://github.com/numpy/numpy/releases)

### Explanation of changes:

- Update version and dependencies
- Add `abs.yaml` for 3.12 build
- Build for 3.12

[PKG-4012]: https://anaconda.atlassian.net/browse/PKG-4012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ