### PR TITLE
update to 2.0.0rc1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,3 @@
-aggregate_branch: 3.12
+# upload to a temp channel for testing
+upload_channels:
+  ad-testing: numpy2 

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -4,14 +4,6 @@ set -ex
 
 cd ${SRC_DIR}
 
-if [[ $target_platform == osx-64 ]]; then
-    # osx-64 error: no member named 'aligned_alloc' in the global namespace; did you mean simply 'aligned_alloc'?
-    # See: https://github.com/numpy/numpy/pull/26123
-    # See: https://github.com/numpy/numpy/issues/25940
-    rm -rf numpy/fft/pocketfft/*
-    mv pocketfft/* numpy/fft/pocketfft/
-fi
-
 UNAME_M=$(uname -m)
 case "$UNAME_M" in
     ppc64*)

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -8,8 +8,8 @@ if [[ $target_platform == osx-64 ]]; then
     # osx-64 error: no member named 'aligned_alloc' in the global namespace; did you mean simply 'aligned_alloc'?
     # See: https://github.com/numpy/numpy/pull/26123
     # See: https://github.com/numpy/numpy/issues/25940
-    rm -rf numpy/fft/pocketfft
-    mv pocketfft numpy/fft/
+    rm -rf numpy/fft/pocketfft/*
+    mv pocketfft/* numpy/fft/pocketfft/
 fi
 
 UNAME_M=$(uname -m)

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -4,6 +4,14 @@ set -ex
 
 cd ${SRC_DIR}
 
+if [[ $target_platform == osx-64 ]]; then
+    # osx-64 error: no member named 'aligned_alloc' in the global namespace; did you mean simply 'aligned_alloc'?
+    # See: https://github.com/numpy/numpy/pull/26123
+    # See: https://github.com/numpy/numpy/issues/25940
+    rm -rf numpy/fft/pocketfft
+    mv pocketfft numpy/fft/
+fi
+
 UNAME_M=$(uname -m)
 case "$UNAME_M" in
     ppc64*)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.26.4" %}
+{% set version = "2.0.0b1" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,14 +6,14 @@ package:
 
 source:
   url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: 2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010
+  sha256: e0bb33a37d0d0b9a19cd41a093877f830e06bd4d989341b9792896cf08e629f7
   patches:                                                # [blas_impl == "mkl" or s390x]
     - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
     - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]
 
 build:
   number: 0
-  # numpy 1.26 no longer supports Python 3.8: https://numpy.org/devdocs/release/1.26.0-notes.html
+  # numpy 2.0.0 no longer supports Python 3.8: https://numpy.org/devdocs/release/2.0.0-notes.html
   # "This release supports Python versions 3.9-3.12"
   skip: True  # [(blas_impl == 'openblas' and win)]
   skip: True  # [py<39 or py>=313]
@@ -45,8 +45,8 @@ outputs:
       host:
         - python
         - pip
-        - cython >=0.29.34,<3.1
-        - meson-python >=0.15.0,<0.16.0
+        - cython >=3.0.6
+        - meson-python >=0.15.0
         - python-build
         # blas
         - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
@@ -106,7 +106,7 @@ outputs:
         - {{ compiler('fortran') }}  # [not osx]
         - nomkl  # [x86 and blas_impl != 'mkl']
         - typing-extensions >=4.2.0
-        - mypy >=1.5.1
+        - mypy >=1.7.1
         - cffi  # [py<310]
         - charset-normalizer
         - meson
@@ -125,12 +125,7 @@ outputs:
         - numpy.linalg.lapack_lite
         - numpy.random.mtrand
         # from numpy/tests/test_public_api.py
-        - numpy.array_api
-        - numpy.array_api.linalg
         - numpy.ctypeslib
-        - numpy.doc
-        - numpy.doc.constants
-        - numpy.doc.ufuncs
         - numpy.dtypes
         - numpy.exceptions
         - numpy.f2py
@@ -141,11 +136,13 @@ outputs:
         - numpy.lib.recfunctions
         - numpy.lib.scimath
         - numpy.lib.stride_tricks
+        - numpy.lib.npyio
+        - numpy.lib.introspect
+        - numpy.lib.array_utils
         - numpy.linalg
         - numpy.ma
         - numpy.ma.extras
         - numpy.ma.mrecords
-        - numpy.matlib
         - numpy.polynomial
         - numpy.polynomial.chebyshev
         - numpy.polynomial.hermite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,17 +7,15 @@ package:
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
     sha256: e0bb33a37d0d0b9a19cd41a093877f830e06bd4d989341b9792896cf08e629f7
-
+    patches:                                                # [blas_impl == "mkl" or s390x]
+      - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
+      - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]
   # osx-64 error: no member named 'aligned_alloc' in the global namespace; did you mean simply 'aligned_alloc'?
   # See: https://github.com/numpy/numpy/pull/26123
   # See: https://github.com/numpy/numpy/issues/25940
   - git_url: https://github.com/mreineck/pocketfft.git    # [osx and x86_64]
     git_rev: 33ae5dc94c9cdc7f1c78346504a85de87cadaa12     # [osx and x86_64]
     folder: pocketfft                                     # [osx and x86_64]
-  
-  patches:                                                # [blas_impl == "mkl" or s390x]
-    - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
-    - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
   build:
     - patch     # [(blas_impl == "mkl" or s390x) and not win]
     - m2-patch  # [(blas_impl == "mkl") and win]
-    - git       # [osx and x86_64]
 
 outputs:
   # this one has all the actual contents

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ outputs:
     build:
       entry_points:
         - f2py = numpy.f2py.f2py2e:main
+        - numpy-config = numpy._configtool:main
       missing_dso_whitelist:  # [s390x]
         - $RPATH/ld64.so.1    # [s390x]
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ requirements:
     - patch     # [(blas_impl == "mkl" or s390x) and not win]
     - m2-patch  # [(blas_impl == "mkl") and win]
     - git       # [osx and x86_64]
-    - git-lfs   # [osx and x86_64]
 
 outputs:
   # this one has all the actual contents

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,16 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-  sha256: e0bb33a37d0d0b9a19cd41a093877f830e06bd4d989341b9792896cf08e629f7
+  - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
+    sha256: e0bb33a37d0d0b9a19cd41a093877f830e06bd4d989341b9792896cf08e629f7
+
+  # osx-64 error: no member named 'aligned_alloc' in the global namespace; did you mean simply 'aligned_alloc'?
+  # See: https://github.com/numpy/numpy/pull/26123
+  # See: https://github.com/numpy/numpy/issues/25940
+  - git_url: https://github.com/mreineck/pocketfft.git    # [osx and x86_64]
+    git_rev: 33ae5dc94c9cdc7f1c78346504a85de87cadaa12     # [osx and x86_64]
+    folder: pocketfft                                     # [osx and x86_64]
+  
   patches:                                                # [blas_impl == "mkl" or s390x]
     - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
     - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]
@@ -24,6 +32,8 @@ requirements:
   build:
     - patch     # [(blas_impl == "mkl" or s390x) and not win]
     - m2-patch  # [(blas_impl == "mkl") and win]
+    - git       # [osx and x86_64]
+    - git-lfs   # [osx and x86_64]
 
 outputs:
   # this one has all the actual contents

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.0b1" %}
+{% set version = "2.0.0rc1" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,16 +6,10 @@ package:
 
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-    sha256: e0bb33a37d0d0b9a19cd41a093877f830e06bd4d989341b9792896cf08e629f7
+    sha256: f0e169ec6cbc1b8e5f6a235845a80961f76f88352082213a1728a0967a761ad2
     patches:                                                # [blas_impl == "mkl" or s390x]
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
       - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]
-  # osx-64 error: no member named 'aligned_alloc' in the global namespace; did you mean simply 'aligned_alloc'?
-  # See: https://github.com/numpy/numpy/pull/26123
-  # See: https://github.com/numpy/numpy/issues/25940
-  - git_url: https://github.com/mreineck/pocketfft.git    # [osx and x86_64]
-    git_rev: 33ae5dc94c9cdc7f1c78346504a85de87cadaa12     # [osx and x86_64]
-    folder: pocketfft                                     # [osx and x86_64]
 
 build:
   number: 0
@@ -139,14 +133,14 @@ outputs:
         - numpy.f2py
         - numpy.fft
         - numpy.lib
-        - numpy.lib.format  # was this meant to be public?
+        - numpy.lib.array_utils
+        - numpy.lib.format
+        - numpy.lib.introspect
         - numpy.lib.mixins
-        - numpy.lib.recfunctions
+        - numpy.lib.npyio
+        - numpy.lib.recfunctions # note: still needs cleaning, was forgotten for 2.0
         - numpy.lib.scimath
         - numpy.lib.stride_tricks
-        - numpy.lib.npyio
-        - numpy.lib.introspect
-        - numpy.lib.array_utils
         - numpy.linalg
         - numpy.ma
         - numpy.ma.extras
@@ -159,11 +153,12 @@ outputs:
         - numpy.polynomial.legendre
         - numpy.polynomial.polynomial
         - numpy.random
+        - numpy.strings
         - numpy.testing
         - numpy.testing.overrides
         - numpy.typing
         - numpy.typing.mypy_plugin
-        - numpy.version  # Should be removed for NumPy 2.0
+        - numpy.version
 
 about:
   home: https://numpy.org/

--- a/recipe/patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch
+++ b/recipe/patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch
@@ -31,10 +31,10 @@ Please submit a full bug report,
 with preprocessed source if appropriate.
 See <https://gcc.gnu.org/bugs/> for instructions.
 
-diff --git a/numpy/core/src/common/npy_config.h b/numpy/core/src/common/npy_config.h
-index e59036688..4337f95ce 100644
---- a/numpy/core/src/common/npy_config.h
-+++ b/numpy/core/src/common/npy_config.h
+diff --git a/numpy/_core/src/common/npy_config.h b/numpy/_core/src/common/npy_config.h
+index e590366888..4337f95ceb 100644
+--- a/numpy/_core/src/common/npy_config.h
++++ b/numpy/_core/src/common/npy_config.h
 @@ -144,13 +144,11 @@
  #undef HAVE_CASINF
  #undef HAVE_CASINL


### PR DESCRIPTION
Changes:
- Update to 2.0.0rc1
- rebase patches
- set destination channel as ad-testing/label/numpy2

Release note: https://github.com/numpy/numpy/releases/tag/v2.0.0rc1
https://github.com/numpy/numpy/tree/v2.0.0rc1
https://github.com/numpy/numpy/blob/v2.0.0rc1/pyproject.toml
https://github.com/numpy/numpy/blob/v2.0.0rc1/meson.build
https://github.com/numpy/numpy/blob/v2.0.0rc1/meson_options.txt
https://github.com/numpy/numpy/blob/v2.0.0rc1/test_requirements.txt