### PR TITLE
Rebuild for win-64. 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
 
 build:
-  number: 0
+  number: 1
   # The Python versions supported for this release are 3.7-3.10
   # numpy 1.21.x set Python upper bound <3.11, see https://github.com/numpy/numpy/commit/1e8d6a83985f3191c63963414981743adc4353cf
   skip: True  # [(blas_impl == 'openblas' and win) or py<37 or py>310]


### PR DESCRIPTION
For some reason, the previous build of 1.21.6 wasn't uploaded for win-64.