### PR TITLE
2.0.0 numpy-base main

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-# upload to a temp channel for testing
-upload_channels:
-  ad-testing: numpy2 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,7 +2,7 @@
 # recommendation is to build numpy-base but not numpy, then build
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
-only_build_numpy_base: no
+only_build_numpy_base: yes
 
 c_compiler:    # [win]
   - vs2019     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,8 +101,7 @@ outputs:
         - pytest >=7.4.0
         - pytest-cov >=4.1.0
         - pytest-xdist
-        # due to hotfix this is the only hypothesis version that works with numpy 2.0.0 and above
-        - hypothesis ==6.111.0
+        - hypothesis >=6.81.1
         - pytz >=2023.3.post1
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.1" %}
+{% set version = "2.0.0" %}
 
 package:
   name: numpy_and_numpy_base
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-    sha256: 485b87235796410c3519a699cfe1faab097e509e90ebb05dcd098db2ae87e7b3
+    sha256: cf5d1c9e6837f8af9f92b6bd3e86d513cdc11f60fd62185cc49ec7d1aba34864
     patches:                                                # [blas_impl == "mkl" or s390x]
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
       - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]
@@ -93,9 +93,6 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_gcd_overflow" %}  # [s390x]
     # skip simd tests because vxe2 feature is not detected when running from prefect
     {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]
-    # https://github.com/numpy/numpy/issues/27045
-    {% set tests_to_skip = tests_to_skip + " or (test_regression and test_gh25784)" %}  # [osx]
-
 
     test:
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,13 +94,14 @@ outputs:
     # skip simd tests because vxe2 feature is not detected when running from prefect
     {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]
 
+
     test:
       requires:
         - pip
         - pytest >=7.4.0
         - pytest-cov >=4.1.0
         - pytest-xdist
-        - hypothesis >=6.81.1
+        - hypothesis ==6.111.0
         - pytz >=2023.3.post1
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,6 +101,7 @@ outputs:
         - pytest >=7.4.0
         - pytest-cov >=4.1.0
         - pytest-xdist
+        # due to hotfix this is the only hypothesis version that works with numpy 2.0.0 and above
         - hypothesis ==6.111.0
         - pytz >=2023.3.post1
         - {{ compiler('c') }}  # [not osx]


### PR DESCRIPTION
Package Name: NumPy
Version: 2.00
Destination Channel: defaults

Links:
	•	JIRA Ticket:  https://anaconda.atlassian.net/browse/PKG-5130
	•	[Upstream Repository](https://github.com/numpy/numpy)  
	•	[Upstream Changelog/Diff](https://github.com/numpy/numpy/compare/v1.26.5...v2.0.0)

Explanation of Changes:
	•	Updated the NumPy base package to version 2.00.
	•	This update is to enable building the MKL packages and prepare for the full version of NumPy 2.00 at a later date.

**Following these instructions to remove errors seen in linux-64 and win-64:** https://github.com/AnacondaRecipes/numpy-feedstock/blob/b43b810ff6405cd8354e76d78ac2c463824a251b/recipe/meta.yaml#L58-L61