### PR TITLE
Rebuild 2.0.2 with mkl v2025

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+# Required for glibc >= 2.26 for intel-openmp to work.
+pkg_build_image_tag: main-rockylinux-8
+
+build_env_vars:
+  ANACONDA_ROCKET_GLIBC: "2.28"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,3 +8,5 @@ c_compiler:    # [win]
   - vs2019     # [win]
 cxx_compiler:  # [win]
   - vs2019     # [win]
+mkl:
+  - 2025.*

--- a/recipe/install_base.bat
+++ b/recipe/install_base.bat
@@ -19,10 +19,10 @@ if errorlevel 1 (
   exit /b 1
 )
 
-:: `pip install dist\numpy*.whl` does not work on windows,
+:: `pip install --no-deps --no-build-isolation dist\numpy*.whl` does not work on windows,
 :: so use a loop; there's only one wheel in dist/ anyway
 for /f %%f in ('dir /b /S .\dist') do (
-    pip install %%f
+    pip install --no-deps --no-build-isolation %%f
     if %ERRORLEVEL% neq 0 exit 1
 )
 

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -29,4 +29,4 @@ $PYTHON -m build --wheel --no-isolation --skip-dependency-check \
     -Csetup-args=-Dlapack=${BLAS} \
     $EXTRA_OPTS \
     || (cat builddir/meson-logs/meson-log.txt && exit 1)
-$PYTHON -m pip install dist/numpy*.whl
+$PYTHON -m pip install --no-deps --no-build-isolation dist/numpy*.whl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]
 
 build:
-  number: 0
+  number: 2
   # numpy 2.0.0 no longer supports Python 3.8: https://numpy.org/devdocs/release/2.0.0-notes.html
   # "This release supports Python versions 3.9-3.12"
   skip: True  # [(blas_impl == 'openblas' and win)]
@@ -42,6 +42,7 @@ outputs:
         - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
@@ -54,10 +55,14 @@ outputs:
         - meson-python >=0.15.0
         - python-build
         # blas
-        - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
+        - mkl-devel {{ mkl }}  # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
       run:
         - python
+      run_constrained:
+        # restrict setuptools: see https://github.com/numpy/numpy/issues/27405
+        # TODO remove when numpy stop using distutils.msvccompiler from setuptools.
+        - setuptools <74
 
   # When building out the initial package set for a new Python version / MKL version the
   # recommendation is to build numpy-base but not numpy, then build
@@ -75,13 +80,14 @@ outputs:
     requirements:
       build:
         # for runtime alignment
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
       host:
         - python
         # these import blas metapackages to ensure consistency with downstream libs that also use blas
-        - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
+        - mkl-devel {{ mkl }}  # [blas_impl == 'mkl']
         - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']
       run:
         - python
@@ -106,7 +112,6 @@ outputs:
     # https://github.com/numpy/numpy/issues/27045
     {% set tests_to_skip = tests_to_skip + " or (test_regression and test_gh25784)" %}  # [osx]
 
-
     test:
       requires:
         - pip
@@ -127,9 +132,8 @@ outputs:
       commands:
         - f2py -h
         - python -c "import numpy; numpy.show_config()"
-        - export OPENBLAS_NUM_THREADS=1  # [unix]
-        - set OPENBLAS_NUM_THREADS=1  # [win]
-        - export CPU_COUNT=4  # [linux and ppc64le]
+        - export OPENBLAS_NUM_THREADS=1   # [unix and blas_impl != 'mkl']
+        - set OPENBLAS_NUM_THREADS=1      # [win and blas_impl != 'mkl']
         - pytest -vv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=50 --durations-min=1.0
       imports:
         - numpy
@@ -186,6 +190,10 @@ about:
   dev_url: https://github.com/numpy/numpy
 
 extra:
+  skip-lints:
+    - missing_imports_or_run_test_py
+    - missing_tests
+    - host_section_needs_exact_pinnings
   recipe-maintainers:
     - jakirkham
     - msarahan


### PR DESCRIPTION
numpy 2.0.2 b1

**Destination channel:** defaults

### Links

- [PKG-7065](https://anaconda.atlassian.net/browse/PKG-7065)
- [Upstream repository](https://github.com/numpy/numpy/tree/v2.0.2)
- Relevant dependency PRs:
  - AnacondaRecipes/intel_repack-feedstock#26
  - AnacondaRecipes/mkl-service-feedstock#6

### Explanation of changes:

- Bumped `mkl` version
- Made linter happy
- Added `run_constrained` to `numpy-base` so CI tests pass when not building/testing `numpy`


[PKG-7065]: https://anaconda.atlassian.net/browse/PKG-7065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ