### PR TITLE
Rebuild 2.1.3 with mkl v2025

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
+# Required for glibc >= 2.26 for intel-openmp to work.
+pkg_build_image_tag: main-rockylinux-8
+
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+   ANACONDA_ROCKET_GLIBC: "2.28"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,3 +8,5 @@ c_compiler:    # [win]
   - vs2019     # [win]
 cxx_compiler:  # [win]
   - vs2019     # [win]
+mkl:
+  - 2025.*

--- a/recipe/install_base.bat
+++ b/recipe/install_base.bat
@@ -19,10 +19,10 @@ if errorlevel 1 (
   exit /b 1
 )
 
-:: `pip install dist\numpy*.whl` does not work on windows,
+:: `pip install --no-deps --no-build-isolation dist\numpy*.whl` does not work on windows,
 :: so use a loop; there's only one wheel in dist/ anyway
 for /f %%f in ('dir /b /S .\dist') do (
-    pip install %%f
+    pip install --no-deps --no-build-isolation %%f
     if %ERRORLEVEL% neq 0 exit 1
 )
 

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -29,4 +29,4 @@ $PYTHON -m build --wheel --no-isolation --skip-dependency-check \
     -Csetup-args=-Dlapack=${BLAS} \
     $EXTRA_OPTS \
     || (cat builddir/meson-logs/meson-log.txt && exit 1)
-$PYTHON -m pip install dist/numpy*.whl
+$PYTHON -m pip install --no-deps --no-build-isolation dist/numpy*.whl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]
 
 build:
-  number: 0
+  number: 2
   # numpy 2.1.3 no longer supports Python 3.9: https://numpy.org/devdocs/release/2.1.3-notes.html
   skip: True  # [(blas_impl == 'openblas' and win)]
   skip: True  # [py<310 or py>=314]
@@ -41,6 +41,7 @@ outputs:
         - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
@@ -53,7 +54,7 @@ outputs:
         - meson-python >=0.15.0
         - python-build
         # blas
-        - mkl-devel  {{ mkl }}  # [blas_impl == "mkl"]
+        - mkl-devel {{ mkl }}  # [blas_impl == "mkl"]
         - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
       run:
         - python
@@ -65,7 +66,7 @@ outputs:
   # When building out the initial package set for a new Python version / MKL version the
   # recommendation is to build numpy-base but not numpy, then build
   # mkl_fft and mkl_random, and then numpy.
-  # If only_build_numpy_base: "yes build numpy-base only; otherwise build all the outputs.
+  # If only_build_numpy_base: "yes" build numpy-base only; otherwise build all the outputs.
   {% if only_build_numpy_base != 'yes' %}
   # numpy is a metapackage that may include mkl_fft and mkl_random both of
   # which require numpy-base to build
@@ -78,19 +79,20 @@ outputs:
     requirements:
       build:
         # for runtime alignment
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
       host:
         - python
         # these import blas metapackages to ensure consistency with downstream libs that also use blas
-        - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
+        - mkl-devel {{ mkl }}  # [blas_impl == 'mkl']
         - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']
       run:
         - python
         - {{ pin_subpackage('numpy-base', exact=True) }}
         # openblas or mkl runtime included with run_exports
-        - mkl_fft  # [blas_impl == 'mkl']
+        - mkl_fft    # [blas_impl == 'mkl']
         - mkl_random # [blas_impl == 'mkl' and (not win or vc>=14)]
       run_constrained:
         # restrict setuptools: see https://github.com/numpy/numpy/issues/27405
@@ -108,12 +110,13 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or test_features" %}  # [s390x]
     # https://github.com/numpy/numpy/issues/27313 - can be removed with clang >=16 update
     {% set tests_to_skip = tests_to_skip + " or (test_unary_spurious_fpexception and (f-cos or f-sin))" %}  # [osx and arm64]
-
+    {% set tests_to_skip = tests_to_skip + " or test_cstruct" %}  # [win and py>312]
 
     test:
       requires:
         - pip
         - pytest >=7.4.0
+        - pytest-cov >=4.1.0
         - pytest-cov >=4.1.0
         - pytest-xdist
         # due to hotfix this is the only hypothesis version that works with numpy 2.0.0 and above
@@ -131,9 +134,8 @@ outputs:
       commands:
         - f2py -h
         - python -c "import numpy; numpy.show_config()"
-        - export OPENBLAS_NUM_THREADS=1  # [unix]
-        - set OPENBLAS_NUM_THREADS=1  # [win]
-        - export CPU_COUNT=4  # [linux and ppc64le]
+        - export OPENBLAS_NUM_THREADS=1   # [unix and blas_impl != 'mkl']
+        - set OPENBLAS_NUM_THREADS=1      # [win and blas_impl != 'mkl']
         - pytest -vv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=50 --durations-min=1.0
       imports:
         - numpy
@@ -190,6 +192,10 @@ about:
   dev_url: https://github.com/numpy/numpy
 
 extra:
+  skip-lints:
+    - host_section_needs_exact_pinnings
+    - missing_imports_or_run_test_py
+    - missing_tests
   recipe-maintainers:
     - jakirkham
     - msarahan


### PR DESCRIPTION
numpy 2.1.3 b1

**Destination channel:** defaults

### Links

- [PKG-7064](https://anaconda.atlassian.net/browse/PKG-7064)
- [Upstream repository](https://github.com/numpy/numpy/tree/v2.1.3)
- Relevant dependency PRs:
  - AnacondaRecipes/intel_repack-feedstock#26
  - AnacondaRecipes/mkl-service-feedstock#6

### Explanation of changes:

- Bumped `mkl` version
- Made linter happy



[PKG-7064]: https://anaconda.atlassian.net/browse/PKG-7064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ