### PR TITLE
Version 2.2.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.2" %}
+{% set version = "2.2.4" %}
 # numpy will by default use the ABI feature level for the first numpy version
 # that added support for the oldest currently-supported CPython version; see
 # https://github.com/numpy/numpy/blob/v2.1.1/numpy/_core/include/numpy/numpyconfig.h#L125
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-    sha256: ed6906f61834d687738d25988ae117683705636936cc605be0bb208b23df4d8f
+    sha256: 9ba03692a45d3eef66559efe1d1096c4b9b75c0986b5dff5530c378fb8331d4f
     patches:                                                # [blas_impl == "mkl" or s390x]
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
       - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]


### PR DESCRIPTION
numpy 2.2.4

Destination channel: defaults

Links
[PKG-7110](https://anaconda.atlassian.net/browse/PKG-7110)
https://github.com/numpy/numpy/tree/v2.2.4
https://github.com/numpy/numpy/compare/v2.2.2...v2.2.4
Explanation of changes:
Version bump

[PKG-7110]: https://anaconda.atlassian.net/browse/PKG-7110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ