### PR TITLE
numpy 1.24.3 rebuild against mkl 2025

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+# Required for glibc >= 2.26 for intel-openmp to work.
+pkg_build_image_tag: main-rockylinux-8
+build_env_vars:
+  ANACONDA_ROCKET_GLIBC: "2.28"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,4 +10,4 @@ cxx_compiler:  # [win]
   - vs2019     # [win]
 
 mkl:
-  - 2023.*
+  - 2025.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,10 @@ source:
     - patches/0006-popcnt_fix.patch                     # [blas_impl == "mkl" and win]
 
 build:
-  number: 1
+  number: 2
   # numpy 1.24.2 no longer supports Python 3.7: https://numpy.org/devdocs/release/1.24.0-notes.html
   # "This release supports Python versions 3.8-3.11"
-  skip: True  # [(blas_impl == 'openblas' and win)]
+  skip: True  # [py>=312]  # numpy 1.24.3 doesn't support Python 3.12+
   force_use_keys:
     - python
 
@@ -40,6 +40,7 @@ outputs:
         - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
@@ -73,6 +74,7 @@ outputs:
     requirements:
       build:
         # for runtime alignment
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
@@ -137,22 +139,22 @@ outputs:
       requires:
         - pip     # force installation or `test_api_importable` will fail
         - setuptools <60.0.0
-        - pytest
+        - pytest 7.3.1
         - pytest-cov
         - pytest-xdist
-        - hypothesis >=6.29.3
+        - hypothesis >=6.29.3, <6.44.0  # Fixed compatibility issue with array_api in older numpy versions
         - pytz >=2021.3
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]
         - nomkl  # [x86 and blas_impl != 'mkl']
         - typing-extensions >=4.2.0
-        - mypy >=0.981
+        - mypy 0.981  # Locked for typing compatibility
       commands:
         - f2py -h
         - python -c "import numpy; numpy.show_config()"
-        - export OPENBLAS_NUM_THREADS=1  # [unix]
-        - set OPENBLAS_NUM_THREADS=1  # [win]
+        - export OPENBLAS_NUM_THREADS=1  # [unix and blas_impl != 'mkl']
+        - set OPENBLAS_NUM_THREADS=1  # [win and blas_impl != 'mkl']
         - export CPU_COUNT=4  # [linux and ppc64le]
         - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0
       imports:


### PR DESCRIPTION
numpy 1.24.3
**Destination channel:** defaults
### Links
- [PKG-7068](https://anaconda.atlassian.net/browse/PKG-7068) 
- [Upstream repository](https://github.com/numpy/numpy)

### Explanation of changes:
- Ensured compatibility with MKL 2025