### PR TITLE
numpy 1.25.2 rebuild against mkl 2025

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+# Required for glibc >= 2.26 for intel-openmp to work.
+pkg_build_image_tag: main-rockylinux-8
+build_env_vars:
+  ANACONDA_ROCKET_GLIBC: "2.28"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,7 +2,7 @@
 # recommendation is to build numpy-base but not numpy, then build
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
-only_build_numpy_base: yes
+only_build_numpy_base: no
 
 c_compiler:    # [win]
   - vs2019     # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,4 +10,4 @@ cxx_compiler:  # [win]
   - vs2019     # [win]
 
 mkl:
-  - 2023.*
+  - 2025.*

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,7 +2,7 @@
 # recommendation is to build numpy-base but not numpy, then build
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
-only_build_numpy_base: no
+only_build_numpy_base: yes
 
 c_compiler:    # [win]
   - vs2019     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
   # numpy 1.25 no longer supports Python 3.8: https://numpy.org/devdocs/release/1.25.0-notes.html
   # "This release supports Python versions 3.9-3.11"
   skip: True  # [(blas_impl == 'openblas' and win)]
-  skip: True  # [py<39 or py>=312]
+  skip: True  # [py<39 or py>=311]
   force_use_keys:
     - python
 
@@ -50,7 +50,7 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.0
-        - setuptools <60.0.0    # [py<=311]
+        - setuptools <74    # [py<=311]
         - wheel                 # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
         - meson >=1.1.0         # [py>=312]
@@ -105,6 +105,8 @@ outputs:
     # Flawed test when using MKL
     # https://github.com/numpy/numpy/issues/16769
     {% set tests_to_skip = tests_to_skip + " or test_overrides" %}  # [blas_impl == 'mkl']
+    # Skip distutils tests that fail due to missing distutils.msvccompiler in Python 3.10+
+    {% set tests_to_skip = tests_to_skip + " or test_mingw32ccompiler or test_system_info or test_mem_policy or test_all_modules_are_expected_2 or test_api_importable" %}
     # https://github.com/numpy/numpy/issues/15243
     {% set tests_to_skip = tests_to_skip + " or test_loss_of_precision" %}  # [s390x]
     # https://github.com/numpy/numpy/issues/3858 - could be related
@@ -141,7 +143,7 @@ outputs:
         - export OPENBLAS_NUM_THREADS=1  # [unix and blas_impl != 'mkl']
         - set OPENBLAS_NUM_THREADS=1  # [win and blas_impl != 'mkl']
         - export CPU_COUNT=4  # [linux and ppc64le]
-        - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0
+        - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})" --ignore=$SP_DIR/numpy/distutils/tests/test_mingw32ccompiler.py --ignore=$SP_DIR/numpy/distutils/tests/test_system_info.py --durations=0
       imports:
         - numpy
         - numpy.core.multiarray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,8 +105,6 @@ outputs:
     # Flawed test when using MKL
     # https://github.com/numpy/numpy/issues/16769
     {% set tests_to_skip = tests_to_skip + " or test_overrides" %}  # [blas_impl == 'mkl']
-    # Skip distutils tests that fail due to missing distutils.msvccompiler in Python 3.10+
-    {% set tests_to_skip = tests_to_skip + " or test_mingw32ccompiler or test_system_info or test_mem_policy or test_all_modules_are_expected_2 or test_api_importable" %}
     # https://github.com/numpy/numpy/issues/15243
     {% set tests_to_skip = tests_to_skip + " or test_loss_of_precision" %}  # [s390x]
     # https://github.com/numpy/numpy/issues/3858 - could be related
@@ -144,7 +142,7 @@ outputs:
         - export OPENBLAS_NUM_THREADS=1  # [unix and blas_impl != 'mkl']
         - set OPENBLAS_NUM_THREADS=1  # [win and blas_impl != 'mkl']
         - export CPU_COUNT=4  # [linux and ppc64le]
-        - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})"
+        - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0
       imports:
         - numpy
         - numpy.core.multiarray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -123,10 +123,10 @@ outputs:
       requires:
         - pip     # force installation or `test_api_importable` will fail
         - pytz
-        - pytest 7.3.1
+        - pytest
         - pytest-cov
         - pytest-xdist
-        - hypothesis >=6.29.3, <6.44.0  # Fixed compatibility issue with array_api in older numpy versions
+        - hypothesis >=6.29.3
         - pytz >=2021.3
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,11 @@ source:
     - patches/0007-enable-meson-build.patch             # [py>=312] https://github.com/numpy/numpy/blob/v1.25.0/building_with_meson.md
 
 build:
-  number: 0
+  number: 1
   # numpy 1.25 no longer supports Python 3.8: https://numpy.org/devdocs/release/1.25.0-notes.html
   # "This release supports Python versions 3.9-3.11"
   skip: True  # [(blas_impl == 'openblas' and win)]
-  skip: True  # [py<39]
+  skip: True  # [py<39 or py>=312]
   force_use_keys:
     - python
 
@@ -42,6 +42,7 @@ outputs:
         - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
@@ -76,6 +77,7 @@ outputs:
     requirements:
       build:
         # for runtime alignment
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
@@ -121,23 +123,23 @@ outputs:
       requires:
         - pip     # force installation or `test_api_importable` will fail
         - pytz
-        - pytest
+        - pytest 7.3.1
         - pytest-cov
         - pytest-xdist
-        - hypothesis >=6.29.3
+        - hypothesis >=6.29.3, <6.44.0  # Fixed compatibility issue with array_api in older numpy versions
         - pytz >=2021.3
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]
         - nomkl  # [x86 and blas_impl != 'mkl']
         - typing-extensions >=4.2.0
-        - mypy >=0.981
+        - mypy 0.981  # Locked for typing compatibility
         - cffi  # [py<310]
       commands:
         - f2py -h
         - python -c "import numpy; numpy.show_config()"
-        - export OPENBLAS_NUM_THREADS=1  # [unix]
-        - set OPENBLAS_NUM_THREADS=1  # [win]
+        - export OPENBLAS_NUM_THREADS=1  # [unix and blas_impl != 'mkl']
+        - set OPENBLAS_NUM_THREADS=1  # [win and blas_impl != 'mkl']
         - export CPU_COUNT=4  # [linux and ppc64le]
         - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=0
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -143,7 +143,7 @@ outputs:
         - export OPENBLAS_NUM_THREADS=1  # [unix and blas_impl != 'mkl']
         - set OPENBLAS_NUM_THREADS=1  # [win and blas_impl != 'mkl']
         - export CPU_COUNT=4  # [linux and ppc64le]
-        - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})" --ignore=$SP_DIR/numpy/distutils/tests/test_mingw32ccompiler.py --ignore=$SP_DIR/numpy/distutils/tests/test_system_info.py --durations=0
+        - pytest -vvv --pyargs numpy -k "not ({{ tests_to_skip }})"
       imports:
         - numpy
         - numpy.core.multiarray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.0
+        # setuptools.distutils moved msvc compiler to a private module in setuptools 60.0.0
         - setuptools <=59.2.0   # [py<=311]
         - wheel                 # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
@@ -128,6 +129,7 @@ outputs:
         - pytest-xdist
         - hypothesis >=6.29.3
         - pytz >=2021.3
+        # setuptools.distutils moved msvc compiler to a private module in setuptools 60.0.0
         - setuptools <=59.2.0  # [py<=311]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.0
-        - setuptools <74    # [py<=311]
+        - setuptools <=59.2.0   # [py<=311]
         - wheel                 # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
         - meson >=1.1.0         # [py>=312]
@@ -130,6 +130,7 @@ outputs:
         - pytest-xdist
         - hypothesis >=6.29.3
         - pytz >=2021.3
+        - setuptools <=59.2.0  # [py<=311]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,8 +129,8 @@ outputs:
         - pytest-xdist
         - hypothesis >=6.29.3
         - pytz >=2021.3
-        # setuptools.distutils moved msvc compiler to a private module in setuptools 60.0.0
-        - setuptools <=59.2.0  # [py<=311]
+        # setuptools.distutils moved msvc compiler to a private module in setuptools 70.0.0
+        - setuptools <69  # [py<=311]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,8 +50,8 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.0
-        # setuptools.distutils moved msvc compiler to a private module in setuptools 60.0.0
-        - setuptools <=59.2.0   # [py<=311]
+        # https://numpy.org/doc/1.25/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools 
+        - setuptools <60  # [py<=311]
         - wheel                 # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
         - meson >=1.1.0         # [py>=312]
@@ -85,6 +85,7 @@ outputs:
       host:
         - python
         - cython >=0.29.34,<3.0
+        # https://numpy.org/doc/1.25/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools 
         - setuptools <60.0.0    # [py<=311]
         - wheel                 # [py<=311]
         - meson-python >=0.10.0 # [py>=312]
@@ -129,8 +130,8 @@ outputs:
         - pytest-xdist
         - hypothesis >=6.29.3
         - pytz >=2021.3
-        # setuptools.distutils moved msvc compiler to a private module in setuptools 70.0.0
-        - setuptools <69  # [py<=311]
+        # https://numpy.org/doc/1.25/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools 
+        - setuptools <60  # [py<=311]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]


### PR DESCRIPTION
numpy 1.25.2
**Destination channel:** defaults
### Links
- [PKG-7067](https://anaconda.atlassian.net/browse/PKG-7067) 
- [Upstream repository](https://github.com/numpy/numpy)

### Explanation of changes:
- Ensured compatibility with MKL 2025

[PKG-7067]: https://anaconda.atlassian.net/browse/PKG-7067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ