### PR TITLE
numpy 1.26.4 rebuild against mkl 2025

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,4 @@
-aggregate_branch: 3.12
+# Required for glibc >= 2.26 for intel-openmp to work.
+pkg_build_image_tag: main-rockylinux-8
+build_env_vars:
+  ANACONDA_ROCKET_GLIBC: "2.28"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,6 +4,9 @@
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: no
 
+mkl:
+  - 2025.*
+
 c_compiler:    # [win]
   - vs2019     # [win]
 cxx_compiler:  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.1
+        - setuptools <=59.2.0   # [py<=311]
         - meson-python >=0.15.0,<0.16.0
         - python-build
         # blas
@@ -103,6 +104,7 @@ outputs:
         - pytest-xdist
         - hypothesis >=6.81.1
         - pytz >=2023.3.post1
+        - setuptools <=59.2.0   # [py<=311]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.1
-        # https://numpy.org/doc/1.25/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools 
+        # https://numpy.org/doc/1.26/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools 
         - setuptools <60  # [py<=311]
         - meson-python >=0.15.0,<0.16.0
         - python-build
@@ -105,7 +105,7 @@ outputs:
         - pytest-xdist
         - hypothesis >=6.81.1
         - pytz >=2023.3.post1
-        # https://numpy.org/doc/1.25/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools 
+        # https://numpy.org/doc/1.26/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools 
         - setuptools <60  # [py<=311]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.1
+        # setuptools.distutils moved msvc compiler to a private module in setuptools 60.0.0
         - setuptools <=59.2.0   # [py<=311]
         - meson-python >=0.15.0,<0.16.0
         - python-build
@@ -104,6 +105,7 @@ outputs:
         - pytest-xdist
         - hypothesis >=6.81.1
         - pytz >=2023.3.post1
+        # setuptools.distutils moved msvc compiler to a private module in setuptools 60.0.0
         - setuptools <=59.2.0   # [py<=311]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0004-Partially-revert-function-blocklisting-for-glibc-lt-2.18.patch # [s390x]
 
 build:
-  number: 0
+  number: 1
   # numpy 1.26 no longer supports Python 3.8: https://numpy.org/devdocs/release/1.26.0-notes.html
   # "This release supports Python versions 3.9-3.12"
   skip: True  # [(blas_impl == 'openblas' and win)]
@@ -37,6 +37,7 @@ outputs:
         - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
@@ -68,6 +69,7 @@ outputs:
     requirements:
       build:
         # for runtime alignment
+        - {{ stdlib('c') }}  # [linux]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - armpl  # [aarch64]
@@ -113,8 +115,8 @@ outputs:
       commands:
         - f2py -h
         - python -c "import numpy; numpy.show_config()"
-        - export OPENBLAS_NUM_THREADS=1  # [unix]
-        - set OPENBLAS_NUM_THREADS=1  # [win]
+        - export OPENBLAS_NUM_THREADS=1  # [unix and blas_impl != 'mkl']
+        - set OPENBLAS_NUM_THREADS=1  # [win and blas_impl != 'mkl']
         - export CPU_COUNT=4  # [linux and ppc64le]
         - pytest -vv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=50 --durations-min=1.0
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,8 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.1
-        # setuptools.distutils moved msvc compiler to a private module in setuptools 70.0.0
-        - setuptools <=69  # [py<=311]
+        # https://numpy.org/doc/1.25/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools 
+        - setuptools <60  # [py<=311]
         - meson-python >=0.15.0,<0.16.0
         - python-build
         # blas
@@ -105,8 +105,8 @@ outputs:
         - pytest-xdist
         - hypothesis >=6.81.1
         - pytz >=2023.3.post1
-        # setuptools.distutils moved msvc compiler to a private module in setuptools 70.0.0
-        - setuptools <=69  # [py<=311]
+        # https://numpy.org/doc/1.25/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools 
+        - setuptools <60  # [py<=311]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,8 @@ outputs:
         - python
         - pip
         - cython >=0.29.34,<3.1
-        # setuptools.distutils moved msvc compiler to a private module in setuptools 60.0.0
-        - setuptools <=59.2.0   # [py<=311]
+        # setuptools.distutils moved msvc compiler to a private module in setuptools 70.0.0
+        - setuptools <=69  # [py<=311]
         - meson-python >=0.15.0,<0.16.0
         - python-build
         # blas
@@ -105,8 +105,8 @@ outputs:
         - pytest-xdist
         - hypothesis >=6.81.1
         - pytz >=2023.3.post1
-        # setuptools.distutils moved msvc compiler to a private module in setuptools 60.0.0
-        - setuptools <=59.2.0   # [py<=311]
+        # setuptools.distutils moved msvc compiler to a private module in setuptools 70.0.0
+        - setuptools <=69  # [py<=311]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]


### PR DESCRIPTION
numpy 1.26.4
**Destination channel:** defaults
### Links
- [PKG-7066](https://anaconda.atlassian.net/browse/PKG-7066) 
- [Upstream repository](https://github.com/numpy/numpy)

### Explanation of changes:
- Ensured compatibility with MKL 2025

[PKG-7066]: https://anaconda.atlassian.net/browse/PKG-7066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ