### PR TITLE
numpy 2.4.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.2" %}
+{% set version = "2.4.3" %}
 # numpy will by default use the ABI feature level for the first numpy version
 # that added support for the oldest currently-supported CPython version; see
 # https://github.com/numpy/numpy/blob/v2.4.2/numpy/_core/include/numpy/numpyconfig.h
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-    sha256: 659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae
+    sha256: 483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd
     patches:                                                # [blas_impl == "mkl" or osx]
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
 
@@ -96,7 +96,7 @@ outputs:
         - pytest >=7.4.0
         - pytest-cov >=4.1.0
         - pytest-xdist
-        - hypothesis >=6.111.0
+        - hypothesis >=6.142.2
         - pytz >=2023.3.post1
         - {{ stdlib('c') }}  # [not osx]
         - {{ compiler('c') }}  # [not osx]
@@ -104,9 +104,9 @@ outputs:
         - {{ compiler('fortran') }}  # [not osx]
         - nomkl  # [x86 and blas_impl != 'mkl']
         - typing-extensions >=4.5.0
-        - mypy >=1.15.0
+        - mypy >=1.18.2
         - charset-normalizer
-        - meson >=1.5.2
+        - meson >=1.8.3,<=1.9
       commands:
         - f2py -h
         - python -c "import numpy; numpy.show_config()"


### PR DESCRIPTION
numpy 2.4.3 

**Destination channel:** Defaults

### Links

- [PKG-12914]
- dev_url:        https://github.com/numpy/numpy/tree/v2.4.3
- conda_forge:    https://github.com/conda-forge/numpy-feedstock
- pypi:           https://pypi.org/project/numpy/2.4.3
- pypi inspector: https://inspector.pypi.io/project/numpy/2.4.3

### Explanation of changes:

- new version number


[PKG-12914]: https://anaconda.atlassian.net/browse/PKG-12914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ