### PR TITLE
numpy 2.4.4 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,9 +5,9 @@
 only_build_numpy_base: no
 
 c_compiler:    # [win]
-  - vs2019     # [win]
+  - vs2022     # [win]
 cxx_compiler:  # [win]
-  - vs2019     # [win]
+  - vs2022     # [win]
 
 c_compiler_version:
   - 17.0.6            # [osx]

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -4,17 +4,6 @@ set -ex
 
 cd ${SRC_DIR}
 
-UNAME_M=$(uname -m)
-case "$UNAME_M" in
-    ppc64*)
-        # Optimizations trigger compiler bug.
-        EXTRA_OPTS="-Csetup-args=-Dcpu-dispatch=min"
-        ;;
-    *)
-        EXTRA_OPTS=""
-        ;;
-esac
-
 if [[ ${blas_impl} == openblas ]]; then
     BLAS=openblas
 else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.3" %}
+{% set version = "2.4.4" %}
 # numpy will by default use the ABI feature level for the first numpy version
 # that added support for the oldest currently-supported CPython version; see
 # https://github.com/numpy/numpy/blob/v2.4.2/numpy/_core/include/numpy/numpyconfig.h
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-    sha256: 483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd
+    sha256: 2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0
     patches:                                                # [blas_impl == "mkl" or osx]
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
 
@@ -112,8 +112,7 @@ outputs:
         - python -c "import numpy; numpy.show_config()"
         - export OPENBLAS_NUM_THREADS=1  # [unix]
         - set OPENBLAS_NUM_THREADS=1  # [win]
-        - export CPU_COUNT=4  # [linux and ppc64le]
-        - pytest -vv --pyargs numpy -k "not ({{ tests_to_skip }})" --durations=50 --durations-min=1.0
+        - pytest -ra -vv -n auto --pyargs numpy -k "not slow and not ({{ tests_to_skip }})" --durations=50 --durations-min=1.0
       imports:
         - numpy
         - numpy.core.multiarray


### PR DESCRIPTION
numpy 2.4.4 

**Destination channel:** Defaults

### Links

- [PKG-13292]
- dev_url:        https://github.com/numpy/numpy/tree/v2.4.4
- conda_forge:    https://github.com/conda-forge/numpy-feedstock
- pypi:           https://pypi.org/project/numpy/2.4.4
- pypi inspector: https://inspector.pypi.io/project/numpy/2.4.4

### Explanation of changes:

- new version number
- upd win c/cpp compiler to vs2022
- cleanup legacy 
- fix pytest to use xdist paralleling


[PKG-13292]: https://anaconda.atlassian.net/browse/PKG-13292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ