### PR TITLE
2.4: Build openblas variant on windows

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,5 +13,13 @@ c_compiler_version:
   - 17.0.6            # [osx]
 cxx_compiler_version:
   - 17.0.6            # [osx]
+
+blas_impl:
+  - mkl                        # [(x86 or x86_64) and not osx]
+  - openblas
+
+fortran_compiler:
+  - flang             # [win]
 fortran_compiler_version:
   - 14.3.0            # [linux]
+  - 20                # [win]

--- a/recipe/install_base.bat
+++ b/recipe/install_base.bat
@@ -3,6 +3,7 @@
 set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
 if "%blas_impl%" == "openblas" (
     set "BLAS=openblas"
+    set "OPENBLAS_ROOT=%LIBRARY_PREFIX%"
 ) else (
     set "BLAS=mkl-sdl"
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   number: 1
-  skip: True  # [py<311]
+  skip: True  # [py<311 or py>=315]
   force_use_keys:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [(blas_impl == 'openblas' and win)]
   skip: True  # [py<311]
   force_use_keys:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<311]
   force_use_keys:
     - python


### PR DESCRIPTION
numpy 2.4: rebuild with openblas/flang for win-64

**Destination channel:** defaults

### Links

- [PKG-13572](https://anaconda.atlassian.net/browse/PKG-13572)

### Explanation of changes:

- add openblas to build matrix for windows and override fortran compiler to flang. Can be removed once https://github.com/AnacondaRecipes/aggregate/pull/438 is available.
- Bump build number
- remove skip
- Add env variable to hep find openblas.


https://anaconda.atlassian.net/browse/PKG-13572

[PKG-13572]: https://anaconda.atlassian.net/browse/PKG-13572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ