### PR TITLE
numpy 2.4.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.4" %}
+{% set version = "2.4.6" %}
 # numpy will by default use the ABI feature level for the first numpy version
 # that added support for the oldest currently-supported CPython version; see
 # https://github.com/numpy/numpy/blob/v2.4.2/numpy/_core/include/numpy/numpyconfig.h
@@ -10,12 +10,12 @@ package:
 
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-    sha256: 2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0
+    sha256: f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda
     patches:                                                # [blas_impl == "mkl" or osx]
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
 
 build:
-  number: 1
+  number: 0
   skip: True  # [py<311 or py>=315]
   force_use_keys:
     - python


### PR DESCRIPTION
## numpy 2.4.6

**Destination channel:** defaults

### Links
- [PKG-14840](https://anaconda.atlassian.net/browse/PKG-14840)
- [GitHub Release](https://github.com/numpy/numpy/releases/tag/v2.4.6)
- [PyPI](https://pypi.org/project/numpy/2.4.6/)

### Explanation of changes:
- Updated numpy from 2.4.4 to 2.4.6
- Reset build number to 0
- No dependency changes (patch release — fixes regression in `arr.conj()`, `np.linalg.svd` with `hermitian=True`, and a refcount bug in NpyStringAcquireAllocator)
- MKL patch still applies cleanly (target file unchanged)
- Python support: 3.11-3.14 (same as 2.4.4)

### Note on automated PRs:
PRs #147 and #148 (automated) incorrectly remove the `only_build_numpy_base` conditional guard which is needed for staged bootstrap builds. This PR preserves the existing recipe structure.

[PKG-14840]: https://anaconda.atlassian.net/browse/PKG-14840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ