### PR TITLE
update to 2.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,23 +83,19 @@ outputs:
     test:
       requires:
         - pip
-        # restrict setuptools: see https://github.com/numpy/numpy/issues/27405
-        # TODO remove when numpy stop using distutils.msvccompiler from setuptools.
-        - setuptools <74
-        - pytest >=7.4.0
-        - pytest-cov >=4.1.0
+        - hypothesis >=6.152.1
+        - pytest >=9.0.3
+        - pytest-cov >=7.1.0
         - pytest-xdist
-        - hypothesis >=6.142.2
-        - pytz >=2023.3.post1
+        - pytest-timeout
+        - charset-normalizer
+        - python-tzdata
         - {{ stdlib('c') }}  # [not osx]
         - {{ compiler('c') }}  # [not osx]
         - {{ compiler('cxx') }}  # [not osx]
         - {{ compiler('fortran') }}  # [not osx]
         - nomkl  # [x86 and blas_impl != 'mkl']
-        - typing-extensions >=4.5.0
-        - mypy >=1.18.2
-        - charset-normalizer
-        - meson >=1.8.3,<=1.9
+        - meson >=1.8.3
       commands:
         - f2py -h
         - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,17 +80,6 @@ outputs:
 
     {% set tests_to_skip = "_not_a_real_test" %}
 
-    # path error in pkg-config on osx only for numpy 2.3.0 on CI
-    {% set tests_to_skip = tests_to_skip + " or test_configtool_pkgconfigdir" %}  # [osx]
-    # NumPy's exp2 function is not raising FloatingPointError for overflow/underflow conditions on Windows, likely due to platform-specific floating-point exception handling differences between glibc and MSVCRT.
-    # This test passes on Linux with glibc ≥2.17 but fails on Windows because np.exp2(2000.0) returns inf instead of raising FloatingPointError.
-    {% set tests_to_skip = tests_to_skip + " or test_exp2" %}  # [win]
-    # NumPy 2.5.0 GA added a BLAS GEMM thread-safety test (test_blas_gemm_thread_safety)
-    # that requires an unreleased dev version of OpenBLAS (0.3.33.112),
-    # but the latest stable release is only 0.3.33 — so the test fails and likely all distros using stable OpenBLAS.
-    # see https://github.com/numpy/numpy/issues/31708
-    {% set tests_to_skip = tests_to_skip + " or test_blas_gemm_thread_safety" %}
-
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.5.0" %}
+{% set version = "2.5.1" %}
 # numpy will by default use the ABI feature level for the first numpy version
 # that added support for the oldest currently-supported CPython version; see
 # https://github.com/numpy/numpy/blob/v2.5.0/numpy/_core/include/numpy/numpyconfig.h#L124
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://github.com/numpy/numpy/releases/download/v{{ version }}/numpy-{{ version }}.tar.gz
-    sha256: 5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c
+    sha256: a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3
     patches:                                                # [blas_impl == "mkl" or osx]
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
 
@@ -113,6 +113,7 @@ outputs:
         - meson >=1.8.3,<=1.9
       commands:
         - f2py -h
+        - pip check
         - python -c "import numpy; numpy.show_config()"
         - export OPENBLAS_NUM_THREADS=1  # [unix]
         - set OPENBLAS_NUM_THREADS=1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,6 +80,10 @@ outputs:
 
     {% set tests_to_skip = "_not_a_real_test" %}
 
+    # NumPy's exp2 function is not raising FloatingPointError for overflow/underflow conditions on Windows, likely due to platform-specific floating-point exception handling differences between glibc and MSVCRT.
+    # This test passes on Linux with glibc ≥2.17 but fails on Windows because np.exp2(2000.0) returns inf instead of raising FloatingPointError.
+    {% set tests_to_skip = tests_to_skip + " or test_exp2" %}  # [win]
+
     test:
       requires:
         - pip
@@ -96,6 +100,8 @@ outputs:
         - {{ compiler('fortran') }}  # [not osx]
         - nomkl  # [x86 and blas_impl != 'mkl']
         - meson >=1.8.3
+        - ninja-base >=1.8.2
+        - pkg-config
       commands:
         - f2py -h
         - pip check


### PR DESCRIPTION
numpy 2.5.1

**Destination channel:** defaults

### Links
- [PKG-16193](https://anaconda.atlassian.net/browse/PKG-16193)
- [PyPI](https://pypi.org/project/numpy/2.5.1/)
- [Release notes](https://github.com/numpy/numpy/releases/tag/v2.5.1)

### Explanation of changes:
- Updated numpy from 2.5.0 to 2.5.1.
- Updated the source SHA256 for the GitHub release tarball.
- Added `pip check` to the existing numpy output test commands.
- Downstream impact is tracked in PKG-16193: patch release, no expected API/ABI break, with follow-up rebuild/update candidates listed by triage.

[PKG-16193]: https://anaconda.atlassian.net/browse/PKG-16193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ