### PR TITLE
PKG-17338 — numpy 2.5.2 py315 metapackage

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -17,6 +17,8 @@ channels:
   - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr7/7d1ebdb
   - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr4/8be4dbf
   - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr21/01caf42
+  - https://staging.continuum.io/pbp/fs/mkl_fft-feedstock/pr16/a6b998a
+  - https://staging.continuum.io/pbp/fs/mkl_random-feedstock/pr13/6b4cbb3
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY315: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,6 +9,14 @@ upload_channels:
 
 channels:
   - ad-testing/label/py315
+  # py315 bootstrap hosts are on PR staging until review-gated promotion.
+  # Strip all staging URLs before merge (U12).
+  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr35/867291d
+  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr25/9e3735b
+  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr7/bce7847
+  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr7/7d1ebdb
+  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr4/8be4dbf
+  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr21/01caf42
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY315: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,16 +9,6 @@ upload_channels:
 
 channels:
   - ad-testing/label/py315
-  # py315 bootstrap hosts are on PR staging until review-gated promotion.
-  # Strip all staging URLs before merge (U12).
-  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr35/867291d
-  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr25/9e3735b
-  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr7/bce7847
-  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr7/7d1ebdb
-  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr4/8be4dbf
-  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr21/01caf42
-  - https://staging.continuum.io/pbp/fs/mkl_fft-feedstock/pr16/a6b998a
-  - https://staging.continuum.io/pbp/fs/mkl_random-feedstock/pr13/6b4cbb3
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY315: True

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,7 +2,7 @@
 # recommendation is to build numpy-base but not numpy, then build
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
-only_build_numpy_base: yes
+only_build_numpy_base: no
 
 c_compiler:    # [win]
   - vs2022     # [win]


### PR DESCRIPTION
## Destination channel
ad-testing/label/py315

## Links
- https://anaconda.atlassian.net/browse/PKG-17338
- Replaces closed stacked PR https://github.com/AnacondaRecipes/numpy-feedstock/pull/157 (base branch deleted when numpy-base #156 merged)

## Explanation
Flip `only_build_numpy_base` to `no` so the numpy metapackage builds against numpy-base + mkl_* already on `ad-testing/label/py315`.

## Notes
Artifacts already promoted from the previous #157 graph. This PR is the U12 merge vehicle onto `master-py3.15.0rc1`.

Made with [Cursor](https://cursor.com)