### PR TITLE
numpy-base 2.5.2: rebuild for free-threaded py314t

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,12 +3,12 @@ build_parameters:
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_FREETHREADING: yes
 channels:
-  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/d27f75f
-  - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/9b1e75c
-  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/1975be3
-  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/d4ee3c7
-  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/ed52c28
-  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/3762582
-  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/fd7905b
-  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/f894c6d
-  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/9bdfa6a
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/4df3dd3
+  - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/cac687d
+  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/1345d3f
+  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/0945775
+  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/62299c3
+  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/2014cc0
+  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/c127684
+  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/4cfc8b8
+  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/7121819

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,10 +5,10 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/4df3dd3
   - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/cac687d
-  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/1345d3f
-  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/0945775
-  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/62299c3
-  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/2014cc0
-  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/c127684
-  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/4cfc8b8
-  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/7121819
+  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/9fd2d26
+  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/f22dbd0
+  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/c60aab5
+  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/3df7021
+  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/f9acde6
+  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/2ea08d7
+  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/35e8844

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,14 @@
+build_parameters:
+  - "--no-test"
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_FREETHREADING: yes
+channels:
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/d27f75f
+  - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/9b1e75c
+  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/1975be3
+  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/d4ee3c7
+  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/ed52c28
+  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/3762582
+  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/fd7905b
+  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/f894c6d
+  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/9bdfa6a

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,7 +2,16 @@
 # recommendation is to build numpy-base but not numpy, then build
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
-only_build_numpy_base: no
+only_build_numpy_base: yes
+# Until AnacondaRecipes/aggregate#534 merges: t-only overlay.
+python:
+  - "3.14.* *_cp314t"
+numpy:
+  - 2.3
+zip_keys:
+  -
+    - python
+    - numpy
 
 c_compiler:    # [win]
   - vs2022     # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,15 +3,6 @@
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: yes
-# Until AnacondaRecipes/aggregate#534 merges: t-only overlay.
-python:
-  - "3.14.* *_cp314t"
-numpy:
-  - 2.3
-zip_keys:
-  -
-    - python
-    - numpy
 
 c_compiler:    # [win]
   - vs2022     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<312 or py>=315]
   force_use_keys:
     - python


### PR DESCRIPTION
numpy - rebuild numpy-base for free-threaded Python 3.14

**Destination channel:** main

### Links
- [Jira](https://anaconda.atlassian.net/browse/PKG-17715)
- [Upstream repository](https://github.com/numpy/numpy)

### Explanation of changes:
- Rebuild numpy-base only for free-threaded Python 3.14
- Python 3.14.7 is already on main. We did not rebuild Python
- Same version (2.5.2). Only the free-threaded variant
- numpy metapackage comes after mkl_fft / mkl_random

### Notes:
- This graph is free-threaded py314t only. Before merge we will delete the python/numpy/zip_keys overlay from recipe/conda_build_config.yaml so master does not stay t-only.
- Tests skipped: pytest/hypothesis cycle
- Please check staging for a `cp314t` or `py314t` artifact: https://staging.continuum.io/pbp/fs/numpy-feedstock/pr162/71f1ef8