### PR TITLE
numpy 2.5.2: rebuild for free-threaded py314t

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,18 @@
+build_parameters:
+  - "--no-test"
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_FREETHREADING: yes
+channels:
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/d27f75f
+  - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/9b1e75c
+  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/1975be3
+  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/d4ee3c7
+  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/ed52c28
+  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/3762582
+  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/fd7905b
+  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/f894c6d
+  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/9bdfa6a
+  - https://staging.continuum.io/pbp/fs/mkl-service-feedstock/pr10/55939a2
+  - https://staging.continuum.io/pbp/fs/mkl_fft-feedstock/pr17/26c44ac
+  - https://staging.continuum.io/pbp/fs/mkl_random-feedstock/pr14/c4b0922
+  - https://staging.continuum.io/pbp/fs/wheel-feedstock/pr18/42eaeb2

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,14 +5,14 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/4df3dd3
   - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/cac687d
-  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/1345d3f
-  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/0945775
-  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/62299c3
-  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/2014cc0
-  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/c127684
-  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/4cfc8b8
-  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/7121819
-  - https://staging.continuum.io/pbp/fs/mkl-service-feedstock/pr10/4c83c3b
-  - https://staging.continuum.io/pbp/fs/mkl_fft-feedstock/pr17/d92dd1b
-  - https://staging.continuum.io/pbp/fs/mkl_random-feedstock/pr14/5c537bf
-  - https://staging.continuum.io/pbp/fs/wheel-feedstock/pr18/3e091ae
+  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/9fd2d26
+  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/f22dbd0
+  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/c60aab5
+  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/3df7021
+  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/f9acde6
+  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/2ea08d7
+  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/35e8844
+  - https://staging.continuum.io/pbp/fs/mkl-service-feedstock/pr10/371e6d9
+  - https://staging.continuum.io/pbp/fs/mkl_fft-feedstock/pr17/a98ce12
+  - https://staging.continuum.io/pbp/fs/mkl_random-feedstock/pr14/238f4bc
+  - https://staging.continuum.io/pbp/fs/wheel-feedstock/pr18/1708729

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,16 +3,16 @@ build_parameters:
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_FREETHREADING: yes
 channels:
-  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/d27f75f
-  - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/9b1e75c
-  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/1975be3
-  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/d4ee3c7
-  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/ed52c28
-  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/3762582
-  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/fd7905b
-  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/f894c6d
-  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/9bdfa6a
-  - https://staging.continuum.io/pbp/fs/mkl-service-feedstock/pr10/55939a2
-  - https://staging.continuum.io/pbp/fs/mkl_fft-feedstock/pr17/26c44ac
-  - https://staging.continuum.io/pbp/fs/mkl_random-feedstock/pr14/c4b0922
-  - https://staging.continuum.io/pbp/fs/wheel-feedstock/pr18/42eaeb2
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/4df3dd3
+  - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/cac687d
+  - https://staging.continuum.io/pbp/fs/pyproject_hooks-feedstock/pr5/1345d3f
+  - https://staging.continuum.io/pbp/fs/pyproject-metadata-feedstock/pr8/0945775
+  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr26/62299c3
+  - https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/2014cc0
+  - https://staging.continuum.io/pbp/fs/meson-python-feedstock/pr22/c127684
+  - https://staging.continuum.io/pbp/fs/python-build-feedstock/pr8/4cfc8b8
+  - https://staging.continuum.io/pbp/fs/cython-feedstock/pr36/7121819
+  - https://staging.continuum.io/pbp/fs/mkl-service-feedstock/pr10/4c83c3b
+  - https://staging.continuum.io/pbp/fs/mkl_fft-feedstock/pr17/d92dd1b
+  - https://staging.continuum.io/pbp/fs/mkl_random-feedstock/pr14/5c537bf
+  - https://staging.continuum.io/pbp/fs/wheel-feedstock/pr18/3e091ae

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,17 +3,6 @@
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: no
-# Until AnacondaRecipes/aggregate#534 merges: t-only overlay.
-python:
-  - "3.14.* *_cp314t"
-numpy:
-  - 2.3
-mkl:
-  - "2025"
-zip_keys:
-  -
-    - python
-    - numpy
 
 c_compiler:    # [win]
   - vs2022     # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,6 +3,17 @@
 # mkl_fft and mkl_random, and then numpy.
 # If only_build_numpy_base: yes, build numpy-base only; otherwise build all the outputs.
 only_build_numpy_base: no
+# Until AnacondaRecipes/aggregate#534 merges: t-only overlay.
+python:
+  - "3.14.* *_cp314t"
+numpy:
+  - 2.3
+mkl:
+  - "2025"
+zip_keys:
+  -
+    - python
+    - numpy
 
 c_compiler:    # [win]
   - vs2022     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<312 or py>=315]
   force_use_keys:
     - python
@@ -26,6 +26,9 @@ outputs:
     script: install_base.sh   # [unix]
     script: install_base.bat  # [win]
     build:
+      # Same feature as python 3.14t so unspecified solves prefer GIL twins.
+      track_features:
+        - free-threading  # [is_freethreading]
       entry_points:
         - f2py = numpy.f2py.f2py2e:main
         - numpy-config = numpy._configtool:main
@@ -57,6 +60,8 @@ outputs:
   # which require numpy-base to build
   - name: numpy
     build:
+      track_features:
+        - free-threading  # [is_freethreading]
       run_exports:
         - numpy >={{ default_abi_level }},<3
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - patches/0003-intel_init_mkl.patch                   # [blas_impl == "mkl"]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<312 or py>=315]
   force_use_keys:
     - python


### PR DESCRIPTION
numpy - rebuild numpy (metapackage) for free-threaded Python 3.14

**Destination channel:** main

This is step two. numpy-base is [PR 162](https://github.com/AnacondaRecipes/numpy-feedstock/pull/162).

### Links
- [Jira](https://anaconda.atlassian.net/browse/PKG-17719)
- [Upstream repository](https://github.com/numpy/numpy)

### Explanation of changes:
- Rebuild the numpy metapackage for free-threaded Python 3.14
- Uses staging mkl_fft / mkl_random cp314t
- Python 3.14.7 is already on main. We did not rebuild Python
- Tests skipped: pytest/hypothesis cycle

### Notes:
- This graph is free-threaded py314t only. Before merge we will delete the python/numpy/zip_keys overlay from recipe/conda_build_config.yaml so master does not stay t-only.
- Please check staging for a `cp314t` or `py314t` numpy artifact (not only numpy-base): https://staging.continuum.io/pbp/fs/numpy-feedstock/pr163/66bb138